### PR TITLE
Add sysexec

### DIFF
--- a/src/main/scala/gwen/eval/EvalEngine.scala
+++ b/src/main/scala/gwen/eval/EvalEngine.scala
@@ -72,18 +72,12 @@ trait EvalEngine[T <: EnvContext] extends LazyLogging {
   def evaluate(step: Step, env: T): Unit = {
     step.expression match {
       case r"""I execute system process "(.+?)"$$$systemproc""" =>
-        
-        systemproc.split(" ").foreach{ str => 
-        	str match {
-        		case ">" => println (s"Redirect detected")
-        		case "|" => println (s"Pipe detected")
-        		case default => println (s"Item: $str") 
-        	}
-        }
-        val sp: ProcessBuilder = scala.sys.process.ProcessBuilderImpl.stringToProcess(systemproc)
-        val arr = systemproc
-        println(s"Hello $arr")
         systemproc.! match {
+          case 0 => 
+          case _ => sys.error(s"The call to $systemproc has failed.")
+        }
+      case r"""I execute a unix system process "(.+?)"$$$systemproc""" =>
+        Seq("/bin/sh", "-c", systemproc).! match {
           case 0 => 
           case _ => sys.error(s"The call to $systemproc has failed.")
         }


### PR DESCRIPTION
Adding in ability to call a system proc from the core engine, using 1 of 2 DSL statements.
1. I execute system process "(.+?)" => which will call any system process checking the return code.
2. I execute a unix system process "(.+?)" => which will call a shell command passing the string to the shell.

The first option does not allow pipes or redirects, the second option does, however is restricted to unix shell.

Tests have been only added to the gwen-web engine.
