### PR TITLE
Tab completion for engine DSLs

### DIFF
--- a/src/main/scala/gwen/dsl/StepKeyword.scala
+++ b/src/main/scala/gwen/dsl/StepKeyword.scala
@@ -33,6 +33,9 @@ object StepKeyword extends Enumeration {
     * keywords by name.
     */
   val names = values map { k => (k.toString -> k) } toMap
+  
+  /** List of all keyword string literals. */
+  val literals = values.map(_.toString).toList
 
 }
 

--- a/src/main/scala/gwen/eval/EnvContext.scala
+++ b/src/main/scala/gwen/eval/EnvContext.scala
@@ -108,7 +108,13 @@ class EnvContext(options: GwenOptions, scopes: ScopedDataStack) extends LazyLogg
     */
   def getStepDef(expression: String): Option[Scenario] = stepDefs.get(expression)
   
-  def getAllStepDefs(): Map[String, Scenario] = stepDefs
+  /**
+   * Gets the list of DSL steps supported by this context.  This implementation 
+   * returns all user defined stepdefs. Subclasses can override to return  
+   * addtional entries. The entries returned by this method are used for tab 
+   * completion in the REPL.
+   */
+  def dsl: List[String] = stepDefs.keys.toList
   
   /**
     * Fail handler.
@@ -190,6 +196,7 @@ class EnvContext(options: GwenOptions, scopes: ScopedDataStack) extends LazyLogg
 
 /** Merges two contexts into one. */
 class HybridEnvContext[A <: EnvContext, B <: EnvContext](val envA: A, val envB: B, val options: GwenOptions, val scopes: ScopedDataStack) extends EnvContext(options, scopes) {
+  override def dsl = envA.dsl ++ envB.dsl
   override def close() {
     try {
       envB.close()

--- a/src/main/scala/gwen/eval/GwenREPL.scala
+++ b/src/main/scala/gwen/eval/GwenREPL.scala
@@ -45,9 +45,8 @@ class GwenREPL[T <: EnvContext](val interpreter: GwenInterpreter[T], val env: T)
     reader.setBellEnabled(false)
     reader.setExpandEvents(false)
     reader.setPrompt("gwen>")
-  
-     reader.addCompleter(new StringsCompleter(StepKeyword.values.map(_.toString).toList ++ List("env", "history", "exit")))
-     reader.addCompleter(new AggregateCompleter(new StringsCompleter(StepKeyword.values.map(_.toString).toList.flatMap(x => env.getAllStepDefs().keys.map(y => s"$x $y")))))
+    reader.addCompleter(new StringsCompleter(StepKeyword.literals ++ List("env", "history", "exit")))
+    reader.addCompleter(new AggregateCompleter(new StringsCompleter(StepKeyword.literals.flatMap(x => env.dsl.distinct.map(y => s"$x $y")))))
   }
   
   /** Reads an input string or command from the command line. */

--- a/src/test/resources/math.dsl
+++ b/src/test/resources/math.dsl
@@ -1,0 +1,4 @@
+x = <integer>
+x = y
+z = x + y
+x == <integer>

--- a/src/test/scala/gwen/sample/math/MathInterpreterTest.scala
+++ b/src/test/scala/gwen/sample/math/MathInterpreterTest.scala
@@ -6,6 +6,9 @@ import gwen.eval.GwenOptions
 import java.io.File
 import org.scalatest.FlatSpec
 import gwen.eval.GwenLauncher
+import gwen.eval.ScopedDataStack
+import gwen.dsl.Step
+import gwen.dsl.StepKeyword
 
 class MathInterpreterTest extends FlatSpec {
   
@@ -22,6 +25,23 @@ class MathInterpreterTest extends FlatSpec {
       case Passed(_) => // excellent :)
       case Failed(_, error) => error.printStackTrace(); fail(error.getMessage())
       case _ => fail("evaluation expected but got noop")
+    }
+  }
+  
+  "math.dsl" should "pass --dry-run test" in {
+    
+    val options = new GwenOptions(dryRun = true);
+    
+    val env = new MathEnvContext(new MathService(), options, new ScopedDataStack())
+    env.scopes.addScope("vars").set("y", "1")
+        
+    val interpreter = new MathInterpreter
+    env.dsl map { dsl =>
+      dsl.replace("<integer>", "1")
+    } foreach { dsl => 
+      StepKeyword.values foreach { keyword =>
+        interpreter.evaluate(Step(keyword, dsl), env)
+      }
     }
   }
 }


### PR DESCRIPTION
This feature adds tab completion support for engine DSL's (in addition to the existing StepDef support). A new method called dsl has been added to the EnvContext for this purpose.  The default implementation returns all loaded StepDefs only. Subclasses in engines can override this to add their own prescribed steps.  All steps returned by the method will have tab completion support in the REPL.  To verify that the DSL is valid, all engines should also include a --dry-run unit test that will exercise each entry. 

The sample math interpreter in the test source has been updated to test this capability. Also, the dev guide (doc/START.md) has been updated to demonstrate how tab completion support can be added to engines.