### PR TITLE
Feature/speed of slideshow

### DIFF
--- a/src/main/scala/gwen/GwenSettings.scala
+++ b/src/main/scala/gwen/GwenSettings.scala
@@ -32,4 +32,6 @@ object GwenSettings {
     */
   def `gwen.feature.failfast`: Boolean = Settings.getOpt("gwen.feature.failfast").getOrElse("true").toBoolean
   
+  def `gwen.report.slideshow.speed`: Double = Settings.getOpt("gwen.report.slideshow.speed").getOrElse("0.01").toString.toDouble
+  
 }

--- a/src/main/scala/gwen/GwenSettings.scala
+++ b/src/main/scala/gwen/GwenSettings.scala
@@ -32,6 +32,10 @@ object GwenSettings {
     */
   def `gwen.feature.failfast`: Boolean = Settings.getOpt("gwen.feature.failfast").getOrElse("true").toBoolean
   
-  def `gwen.report.slideshow.speed`: Double = Settings.getOpt("gwen.report.slideshow.speed").getOrElse("0.01").toString.toDouble
+  /**
+   * Provides access to the `gwen.report.slideshow.framespersecond` property setting
+   * used to set the default frame per second (speed) of the slideshow (default value is 1).
+   */
+  def `gwen.report.slideshow.framespersecond`: Int = Settings.getOpt("gwen.report.slideshow.framespersecond").map(_.toInt).getOrElse(1)
   
 }

--- a/src/main/scala/gwen/report/html/HtmlReportFormatter.scala
+++ b/src/main/scala/gwen/report/html/HtmlReportFormatter.scala
@@ -426,7 +426,7 @@ trait HtmlReportFormatter extends ReportFormatter {
         $$('#play-pause').addClass("glyphicon-pause");
         $$('#play-pause').attr("title", "Pause");
         if ($$('#slides').reel('frame') == ${screenshots.length}) { $$('#slides').reel('frame', 1); }
-        $$('#slides').trigger("play", parseInt($$('#frames-per-sec').val()) * unitSpeed);
+        $$('#slides').trigger("play", getFramesPerSec() * unitSpeed);
       }
       function getFramesPerSec() {
         return parseInt($$('#frames-per-sec').val());

--- a/src/main/scala/gwen/report/html/HtmlReportFormatter.scala
+++ b/src/main/scala/gwen/report/html/HtmlReportFormatter.scala
@@ -377,6 +377,8 @@ trait HtmlReportFormatter extends ReportFormatter {
     <center>
       <div id="loading-div"><span class="glyphicon glyphicon-download" aria-hidden="true"></span> Loading slides, please wait..</div>
       <div id="controls-div" style="display: none;">
+        <button id="increase-speed-btn" class="btn btn-default btn-lg" title="Increase Speed"><span class="glyphicon glyphicon-plus" aria-hidden="true"></span></button>
+        <button id="decrease-speed-btn" class="btn btn-default btn-lg" title="Decrease Speed"><span class="glyphicon glyphicon-minus" aria-hidden="true"></span></button>
         <button id="fast-back-btn" class="btn btn-default btn-lg" title="Rewind to start"><span class="glyphicon glyphicon-fast-backward" aria-hidden="true"></span></button>
         <button id="step-back-btn" class="btn btn-default btn-lg" title="Step backward"><span class="glyphicon glyphicon-step-backward" aria-hidden="true"></span></button>
         <button id="play-pause-btn" class="btn btn-default btn-lg" title="Play"><span id="play-pause" class="glyphicon glyphicon-play" aria-hidden="true"></span></button>
@@ -395,7 +397,7 @@ trait HtmlReportFormatter extends ReportFormatter {
       $$('#slides').reel({
         images: [ ${screenshots.map(_.getName()).mkString("'attachments/","','attachments/","'")} ],
         frames: ${screenshots.length},
-        speed: 0,
+        speed: 0.1,
         indicator: 5,
         responsive: true,
         loops: true,
@@ -418,6 +420,14 @@ trait HtmlReportFormatter extends ReportFormatter {
         if ($$('#slides').reel('frame') == ${screenshots.length}) { $$('#slides').reel('frame', 1); }
         $$('#slides').trigger("play", 2 / ${screenshots.length});
       }
+      function decreaseSpeed() {
+        if ($$('#slides').reel('speed') > 0) {
+          $$('#slides').reel('speed', parseFloat(($$('#slides').reel('speed') - 0.01).toFixed(2)));
+        }
+      }
+      function increaseSpeed() {
+        $$('#slides').reel('speed', parseFloat(($$('#slides').reel('speed') + 0.01).toFixed(2)));
+      }
       function stop() {
         $$('#slides').trigger("stop");
         $$('#play-pause').removeClass("glyphicon-pause");
@@ -425,6 +435,8 @@ trait HtmlReportFormatter extends ReportFormatter {
         $$('#play-pause').attr("title", "Play");
       }
       $$(function() {
+        $$('#increase-speed-btn').click(function(e) { increaseSpeed() });
+        $$('#decrease-speed-btn').click(function(e) { decreaseSpeed() });
         $$('#fast-back-btn').click(function(e) { $$('#slides').reel('frame', 1); stop(); });
         $$('#step-back-btn').click(function(e) { $$('#slides').trigger('stepRight'); stop(); });
         $$('#play-pause-btn').click(function() { 


### PR DESCRIPTION
Added controls to adjust the number of frames displayed per second in the slideshow.  1 to 10 frames per second is supported.  Users can click the + or - buttons to speed up or slow down or select a specific speed in a dropdown.  The default rate of 1 frame per second is overridable through the gwen.report.slideshow.framespersecond property setting.