### PR TITLE
Feature stepdef params

### DIFF
--- a/doc/START.md
+++ b/doc/START.md
@@ -196,9 +196,14 @@ trait MathEvalEngine extends EvalEngine[MathEnvContext] {
           logger.info(s"evaluating z = $xvalue + $yvalue")
           val zresult = env.mathService.plus(xvalue, yvalue)
           vars.set("z", zresult.toString)
+        } getOrElse {
+          vars.set("z", "0") // --dry-run binding
         }
       case r"([a-z])$x == (\d+)$value" =>
-        assert (vars.get(x).toInt == value.toInt)
+        val xvalue = vars.get(x).toInt
+        env.execute {
+          assert (xvalue.toInt == value.toInt)
+        }ß
       case _ =>
         super.evaluate(step, env)
     }

--- a/features/sample/math/Math.meta
+++ b/features/sample/math/Math.meta
@@ -23,16 +23,16 @@ Scenario: ++x
      
 @StepDef
 Scenario: z = x + <y>
-    Given y = ${<y>}
+    Given y = $<y>
      Then z = x + y
      
 @StepDef
 Scenario: z = <x> + <y>
-    Given x = ${<x>}
-      And y = ${<y>}
+    Given x = $<x>
+      And y = $<y>
      Then z = x + y
      
 @StepDef
 Scenario: z = <x> + y
-    Given x = ${<x>}
+    Given x = $<x>
      Then z = x + y

--- a/features/sample/math/Math.meta
+++ b/features/sample/math/Math.meta
@@ -18,6 +18,21 @@
 
 @StepDef
 Scenario: ++x
-    Given y = 1
-     When z = x + y
+    Given z = x + 1
      Then x = z
+     
+@StepDef
+Scenario: z = x + <y>
+    Given y = ${<y>}
+     Then z = x + y
+     
+@StepDef
+Scenario: z = <x> + <y>
+    Given x = ${<x>}
+      And y = ${<y>}
+     Then z = x + y
+     
+@StepDef
+Scenario: z = <x> + y
+    Given x = ${<x>}
+     Then z = x + y

--- a/features/sample/math/MetaMath.feature
+++ b/features/sample/math/MetaMath.feature
@@ -20,6 +20,20 @@ Scenario: Incrementing 0 should yield 1
     Given x = 0
      When ++x
      Then x == 1
+     
+Scenario: Addition with stepdef parameters
+    Given z = 1 + 2
+     Then z == 3
+     
+Scenario: Addition using stepdef with leading parameter
+    Given y = 1
+     When z = 2 + y
+     Then z == 3
+     
+Scenario: Addition using stepdef with trailing parameter
+    Given x = 1
+     When z = x + 2
+     Then z == 3
 
 
   

--- a/src/main/scala/gwen/dsl/SpecAST.scala
+++ b/src/main/scala/gwen/dsl/SpecAST.scala
@@ -230,7 +230,7 @@ object Step {
   def apply(step: Step, expression: String): Step =
     new Step(step.keyword, expression, step.status, step.attachments) tap { _.pos = step.pos }
   def apply(step: Step, stepDef: Scenario): Step =
-    new Step(step.keyword, stepDef.name, stepDef.evalStatus, stepDef.steps.flatMap(_.attachments), Some(stepDef)) tap { _.pos = step.pos }
+    new Step(step.keyword, step.expression, stepDef.evalStatus, stepDef.steps.flatMap(_.attachments), Some(stepDef)) tap { _.pos = step.pos }
   def apply(step: Step, status: EvalStatus, attachments: List[(String, File)]): Step =
-    new Step(step.keyword, step.expression, status, attachments) tap { _.pos = step.pos }
+    new Step(step.keyword, step.expression, status, attachments, step.stepDef) tap { _.pos = step.pos }
 }

--- a/src/main/scala/gwen/dsl/SpecNormaliser.scala
+++ b/src/main/scala/gwen/dsl/SpecNormaliser.scala
@@ -73,7 +73,7 @@ trait SpecNormaliser {
     *         with the same name is found  
     */
   private def noDuplicateStepDefs(scenarios: List[Scenario], featureFile: Option[File] = None): List[Scenario] = scenarios tap { scenarios =>
-    val duplicates = scenarios.filter(_.isStepDef).groupBy(_.name.replaceAll("<.+?>", "<>")) filter { case (_, stepDefs) => stepDefs.size > 1 }
+    val duplicates = scenarios.filter(_.isStepDef).groupBy(_.name.replaceAll("<.+?>", "<?>")) filter { case (_, stepDefs) => stepDefs.size > 1 }
     val dupCount = duplicates.size
     if (dupCount > 0) {
       val msg = s"Ambiguous condition${if (dupCount > 1) "s" else ""}${featureFile.map(f => s" in file $f").getOrElse("")}" 

--- a/src/main/scala/gwen/dsl/SpecNormaliser.scala
+++ b/src/main/scala/gwen/dsl/SpecNormaliser.scala
@@ -73,7 +73,7 @@ trait SpecNormaliser {
     *         with the same name is found  
     */
   private def noDuplicateStepDefs(scenarios: List[Scenario], featureFile: Option[File] = None): List[Scenario] = scenarios tap { scenarios =>
-    val duplicates = scenarios.filter(_.isStepDef).groupBy(_.name) filter { case (_, stepDefs) => stepDefs.size > 1 }
+    val duplicates = scenarios.filter(_.isStepDef).groupBy(_.name.replaceAll("<.+?>", "<>")) filter { case (_, stepDefs) => stepDefs.size > 1 }
     val dupCount = duplicates.size
     if (dupCount > 0) {
       val msg = s"Ambiguous condition${if (dupCount > 1) "s" else ""}${featureFile.map(f => s" in file $f").getOrElse("")}" 

--- a/src/main/scala/gwen/eval/EnvContext.scala
+++ b/src/main/scala/gwen/eval/EnvContext.scala
@@ -146,7 +146,7 @@ class EnvContext(options: GwenOptions, scopes: ScopedDataStack) extends LazyLogg
             featureScope.set(name, value)
           }
           getStepDef(name) tap { stepDef =>
-            logger.info(s"Mapped $expression to StepDef: ${stepDef.get.name} where { ${(params.map { case (n, v) => s"$n=$v"}).mkString(", ")} }")
+            logger.info(s"Mapped $expression to StepDef: ${stepDef.get.name} { ${(params.map { case (n, v) => s"$n=$v"}).mkString(", ")} }")
           }
         case _ => None
       }

--- a/src/main/scala/gwen/eval/GwenInterpreter.scala
+++ b/src/main/scala/gwen/eval/GwenInterpreter.scala
@@ -273,8 +273,13 @@ class GwenInterpreter[T <: EnvContext] extends GwenInfo with SpecParser with Spe
               } catch {
                 case e: UndefinedStepException =>
                   env.getStepDefWithParams(step.expression) match {
-                    case Some(stepDef) => 
+                    case Some((stepDef, params)) =>
+                      // TODO push params to local stack instead
+                      params foreach { case (name, value) =>
+                        env.featureScope.set(name, value)
+                      }
                       evalStepDef(stepDef, step, env)
+                      // TODO pop params off local stack
                     case _ => throw e
                   }
               }

--- a/src/main/scala/gwen/eval/GwenInterpreter.scala
+++ b/src/main/scala/gwen/eval/GwenInterpreter.scala
@@ -274,12 +274,12 @@ class GwenInterpreter[T <: EnvContext] extends GwenInfo with SpecParser with Spe
                 case e: UndefinedStepException =>
                   env.getStepDefWithParams(step.expression) match {
                     case Some((stepDef, params)) =>
-                      // TODO push params to local stack instead
-                      params foreach { case (name, value) =>
-                        env.featureScope.set(name, value)
+                      env.localScope.push(stepDef.name, params)
+                      try {
+                        evalStepDef(stepDef, step, env)
+                      } finally {
+                        env.localScope.pop
                       }
-                      evalStepDef(stepDef, step, env)
-                      // TODO pop params off local stack
                     case _ => throw e
                   }
               }

--- a/src/main/scala/gwen/eval/GwenInterpreter.scala
+++ b/src/main/scala/gwen/eval/GwenInterpreter.scala
@@ -269,14 +269,15 @@ class GwenInterpreter[T <: EnvContext] extends GwenInfo with SpecParser with Spe
           doEvaluate(iStep, env) { step =>
               try {
                 engine.evaluate(step, env)
+                step
               } catch {
                 case e: UndefinedStepException =>
                   env.getStepDefWithParams(step.expression) match {
-                    case Some(stepDef) => evalStepDef(stepDef, step, env)
+                    case Some(stepDef) => 
+                      evalStepDef(stepDef, step, env)
                     case _ => throw e
                   }
               }
-              step
           }
         } else {
           iStep
@@ -305,8 +306,8 @@ class GwenInterpreter[T <: EnvContext] extends GwenInfo with SpecParser with Spe
   private def doEvaluate(step: Step, env: T)(evalFunction: (Step) => Step): Step = {
     val start = System.nanoTime - step.evalStatus.nanos
     (Try(evalFunction(step)) match {
-      case TrySuccess(step) => 
-        Step(step, Passed(System.nanoTime - start), env.attachments)
+      case TrySuccess(passedStep) => 
+        Step(passedStep, Passed(System.nanoTime - start), env.attachments)
       case TryFailure(error) =>
         val failure = Failed(System.nanoTime - start, new StepFailure(step, error))
         env.fail(failure)

--- a/src/main/scala/gwen/eval/GwenREPL.scala
+++ b/src/main/scala/gwen/eval/GwenREPL.scala
@@ -79,8 +79,8 @@ class GwenREPL[T <: EnvContext](val interpreter: GwenInterpreter[T], val env: T)
       Some(history.toString())
     case r"!(\d+)$$$historyValue" =>
       (history.get(historyValue.toInt).toString) match {
-        case x if input.equals(x) 
-        	=> Some(s"Unable to refer to self history - !$historyValue")
+        case x if input.equals(x) => 
+          Some(s"Unable to refer to self history - !$historyValue")
         case s => println("--> "+s); eval(s)
       }
     case r"exit|bye|quit" => 

--- a/src/main/scala/gwen/eval/LocalDataStack.scala
+++ b/src/main/scala/gwen/eval/LocalDataStack.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2014-2015 Branko Juric, Brady Wood
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gwen.eval
+
+import scala.collection.mutable.Stack
+
+import gwen.Predefs.Kestrel
+import gwen.errors.unboundAttributeError
+import play.api.libs.json.JsObject
+import play.api.libs.json.Json
+import play.api.libs.json.Json.toJsFieldJsValueWrapper
+
+/**
+  * Manages and maintains an in memory stack of [[ScopedData]] objects
+  * for storing locally scoped StepDef parameters.
+  * 
+  * @author Branko Juric  
+  */
+class LocalDataStack() {
+
+  /**
+    * The locally scoped data stack.
+    */
+  private val localData = Stack[ScopedData]()
+  
+  /**
+    * Clears all items in the local stack.
+    */
+  def reset() {
+    localData.clear()
+  }
+  
+  /**
+    * Adds the given parameters (name-value pairs) to a new scope 
+    * and pushes it onto the stack
+    * 
+    * @param name the name to give to the scope
+    * @param params the parameters to add
+    * @return the newly added scope
+    */
+  def push(name: String, params: List[(String, String)]): ScopedData = { 
+    ScopedData(name) tap { data =>
+      params foreach { case (pname, pvalue) =>
+        data.set(pname, pvalue)
+      }
+      localData.push(data)
+    }
+  }
+  
+  /** Pops the current data object off the stack. */
+  def pop = localData.pop
+  
+  /**
+    * Finds and retrieves an attribute bound in the local data stack.
+    *
+    * @param name the name of the attribute to find
+    * @return Some(value) if a value is found or None otherwise
+    */
+  def get(name: String): String = 
+    (localData.toIterator map (_.getOpt(name)) collectFirst { 
+      case Some(value) => value 
+    }).getOrElse(unboundAttributeError(name, "local"))
+  
+  /**
+    * Returns a string representation of the entire attribute stack 
+    * as a JSON object.
+    */
+  def json: JsObject = Json.obj("localScope" -> (localData.reverse map (_.json)))
+  
+}
+

--- a/src/main/scala/gwen/eval/ScopedDataStack.scala
+++ b/src/main/scala/gwen/eval/ScopedDataStack.scala
@@ -73,11 +73,19 @@ class ScopedDataStack() {
     */
   private var scopes: Stack[ScopedData] = _
   
+  /** 
+    *  Provides access to the local StepDef scope (StepDef parameters
+    *  are pushed and poped in and out of this scope as StepDef calls
+    *  are made). 
+    */
+  private[eval] val localScope = new LocalDataStack()
+  
   reset()
   
   /** Resets the data stack. */
   def reset() {
       scopes = Stack[ScopedData]() tap { _ push ScopedData("feature") }
+      localScope.reset()
   }
   
   /**
@@ -155,9 +163,9 @@ class ScopedDataStack() {
     * the attribute is the one that is returned.
     *
     * @param name the name of the attribute to find
-    * @return Some(value) if the attribute found or None otherwise
-    * @throws gwen.errors.UnboundAttributeException if the attribute is bound 
-    *         to the given name
+    * @return the attribute value
+    * @throws gwen.errors.UnboundAttributeException if the attribute is 
+    *         not bound to the given name
     */
   def get(name: String): String = 
     getOpt(name).getOrElse(unboundAttributeError(name, current.scope))
@@ -232,7 +240,7 @@ class ScopedDataStack() {
         getAllIn(featureScope.scope, name)
       case x => x
     }
-    
+  
   /**
     * Returns a string representation of the entire attribute stack 
     * as a JSON object.

--- a/src/main/scala/gwen/eval/support/InterpolationSupport.scala
+++ b/src/main/scala/gwen/eval/support/InterpolationSupport.scala
@@ -25,12 +25,16 @@ import com.typesafe.scalalogging.slf4j.LazyLogging
 trait InterpolationSupport extends LazyLogging {
 
   private val propertySyntax = """^(.*)\$\{(.+?)\}(.*)$""".r
+  private val paramSyntax = """^(.*)\$<(.+?)>(.*)$""".r
   
   @tailrec
   final def interpolate(source: String)(resolve: String => String): String = source match {
-      case propertySyntax(prefix, binding, suffix) =>
-        logger.debug(s"Resolving property-syntax binding: $${$binding}")
-        interpolate(s"$prefix${resolve(binding)}$suffix") { resolve }
+      case propertySyntax(prefix, property, suffix) =>
+        logger.debug(s"Resolving property-syntax binding: $${$property}")
+        interpolate(s"$prefix${resolve(property)}$suffix") { resolve }
+      case paramSyntax(prefix, param, suffix) =>
+        logger.debug(s"Resolving param-syntax binding: $${$param}")
+        interpolate(s"$prefix${resolve(s"<${param}>")}$suffix") { resolve }
       case r"""(.+?)$prefix"\s*\+\s*(.+?)$binding\s*\+\s*"(.+?)$suffix""" =>
         logger.debug(s"Resolving concat-syntax binding: + $binding +")
         interpolate(s"$prefix${resolve(binding)}$suffix") { resolve }

--- a/src/main/scala/gwen/report/html/HtmlReportFormatter.scala
+++ b/src/main/scala/gwen/report/html/HtmlReportFormatter.scala
@@ -322,7 +322,7 @@ trait HtmlReportFormatter extends ReportFormatter {
                 <div class="bg-${cssStatus(status)}">
                   <span class="pull-right"><small>${durationOrStatus(step.evalStatus)}</small></span>
                   <div class="line-no"><small>${step.pos.line}</small></div>
-                  <div class="keyword-right"><strong>${step.keyword}</strong></div> ${(step.stepDef.map { stepDef => if (status == StatusKeyword.Failed) escape(step.expression) else formatStepDefLink(stepDef, status, s"${stepId}-${stepDef.pos.line}")}).getOrElse(escape(step.expression))}
+                  <div class="keyword-right"><strong>${step.keyword}</strong></div> ${(step.stepDef.map { stepDef => if (status == StatusKeyword.Failed) escape(step.expression) else formatStepDefLink(step, status, s"${stepId}-${stepDef.pos.line}")}).getOrElse(escape(step.expression))}
                   ${formatAttachments(step.attachments, status)} ${(step.stepDef.map { stepDef => formatStepDefDiv(stepDef, status, s"${stepId}-${stepDef.pos.line}", isMeta)}).getOrElse("")}
                 </div>
                 ${if (status == StatusKeyword.Failed && !step.stepDef.isDefined) s"""
@@ -335,8 +335,8 @@ trait HtmlReportFormatter extends ReportFormatter {
                 </ul>""" else ""}
               </li>"""
   
-  private def formatStepDefLink(stepDef: Scenario, status: StatusKeyword.Value, stepDefId: String): String = 
-    s"""<a role="button" data-toggle="collapse" href="#${stepDefId}" aria-expanded="true" aria-controls="${stepDefId}">${escape(stepDef.name)}</a>"""
+  private def formatStepDefLink(step: Step, status: StatusKeyword.Value, stepDefId: String): String = 
+    s"""<a role="button" data-toggle="collapse" href="#${stepDefId}" aria-expanded="true" aria-controls="${stepDefId}">${escape(step.expression)}</a>"""
                   
   private def formatStepDefDiv(stepDef: Scenario, status: StatusKeyword.Value, stepDefId: String, isMeta: Boolean): String = s"""
                   <div id="${stepDefId}" class="panel-collapse collapse${if (status != StatusKeyword.Passed) " in" else ""}" role="tabpanel" ${if (!isMeta) """style="padding-left: 40px;"""" else ""}>

--- a/src/test/scala/gwen/dsl/SpecNormaliserTest.scala
+++ b/src/test/scala/gwen/dsl/SpecNormaliserTest.scala
@@ -79,4 +79,23 @@ class SpecNormaliserTest extends FlatSpec with Matchers with SpecNormaliser {
     }
   }
   
+  "Meta with duplicate step def with params" should "error" in {
+    val meta = FeatureSpec(
+    Feature("meta1", Nil), None, List(
+      Scenario(Set[Tag]("@StepDef"), "stepdef <number>", None, List(
+        Step(StepKeyword.Given, "step 1", Passed(2)),
+        Step(StepKeyword.When, "step 2", Passed(1)),
+        Step(StepKeyword.Then, "step 3", Passed(2)))
+      ),
+      Scenario(Set[Tag]("@StepDef"), "stepdef <index>", None, List(
+        Step(StepKeyword.Given, "step 1", Passed(2)),
+        Step(StepKeyword.When, "step 2", Passed(1)),
+        Step(StepKeyword.Then, "step 3", Passed(2)))
+      )))
+      
+  intercept[AmbiguousCaseException] {
+    normalise(meta, None)
+    }
+  }
+  
 }

--- a/src/test/scala/gwen/dsl/SpecNormaliserTest.scala
+++ b/src/test/scala/gwen/dsl/SpecNormaliserTest.scala
@@ -24,58 +24,58 @@ class SpecNormaliserTest extends FlatSpec with Matchers with SpecNormaliser {
   
   "Feature with no step defs" should "normalise without error" in {
     val feature = FeatureSpec(
-	  Feature("feature1", Nil), None, List(
-	    Scenario(Set[Tag](), "scenario1", None, List(
-	      Step(StepKeyword.Given, "step 1", Passed(2)),
-	      Step(StepKeyword.Given, "step 2", Passed(1)),
-	      Step(StepKeyword.Given, "step 3", Passed(2)))
-	    )))
-	normalise(feature, None)
+    Feature("feature1", Nil), None, List(
+      Scenario(Set[Tag](), "scenario1", None, List(
+        Step(StepKeyword.Given, "step 1", Passed(2)),
+        Step(StepKeyword.Given, "step 2", Passed(1)),
+        Step(StepKeyword.Given, "step 3", Passed(2)))
+      )))
+  normalise(feature, None)
   }
   
   "Meta with one step def" should "normalise without error" in {
     val meta = FeatureSpec(
-	  Feature("meta1", Nil), None, List(
-	    Scenario(Set[Tag]("@StepDef"), "stepdef1", None, List(
-	      Step(StepKeyword.Given, "step 1", Passed(2)),
-	      Step(StepKeyword.When, "step 2", Passed(1)),
-	      Step(StepKeyword.Then, "step 3", Passed(2)))
-	    )))
-	normalise(meta, None)
+    Feature("meta1", Nil), None, List(
+      Scenario(Set[Tag]("@StepDef"), "stepdef1", None, List(
+        Step(StepKeyword.Given, "step 1", Passed(2)),
+        Step(StepKeyword.When, "step 2", Passed(1)),
+        Step(StepKeyword.Then, "step 3", Passed(2)))
+      )))
+  normalise(meta, None)
   }
   
   "Meta with multiple unique step defs" should "normalise without error" in {
     val meta = FeatureSpec(
-	  Feature("meta1", Nil), None, List(
-	    Scenario(Set[Tag]("@StepDef"), "stepdef1", None, List(
-	      Step(StepKeyword.Given, "step 1", Passed(2)),
-	      Step(StepKeyword.When, "step 2", Passed(1)),
-	      Step(StepKeyword.Then, "step 3", Passed(2)))
-	    ),
-	    Scenario(Set[Tag]("@StepDef"), "stepdef2", None, List(
-	      Step(StepKeyword.Given, "step 1", Passed(2)),
-	      Step(StepKeyword.When, "step 2", Passed(1)),
-	      Step(StepKeyword.Then, "step 3", Passed(2)))
-	    )))
-	normalise(meta, None)
+    Feature("meta1", Nil), None, List(
+      Scenario(Set[Tag]("@StepDef"), "stepdef1", None, List(
+        Step(StepKeyword.Given, "step 1", Passed(2)),
+        Step(StepKeyword.When, "step 2", Passed(1)),
+        Step(StepKeyword.Then, "step 3", Passed(2)))
+      ),
+      Scenario(Set[Tag]("@StepDef"), "stepdef2", None, List(
+        Step(StepKeyword.Given, "step 1", Passed(2)),
+        Step(StepKeyword.When, "step 2", Passed(1)),
+        Step(StepKeyword.Then, "step 3", Passed(2)))
+      )))
+  normalise(meta, None)
   }
   
   "Meta with duplicate step def" should "error" in {
     val meta = FeatureSpec(
-	  Feature("meta1", Nil), None, List(
-	    Scenario(Set[Tag]("@StepDef"), "stepdef1", None, List(
-	      Step(StepKeyword.Given, "step 1", Passed(2)),
-	      Step(StepKeyword.When, "step 2", Passed(1)),
-	      Step(StepKeyword.Then, "step 3", Passed(2)))
-	    ),
-	    Scenario(Set[Tag]("@StepDef"), "stepdef1", None, List(
-	      Step(StepKeyword.Given, "step 1", Passed(2)),
-	      Step(StepKeyword.When, "step 2", Passed(1)),
-	      Step(StepKeyword.Then, "step 3", Passed(2)))
-	    )))
-	    
-	intercept[AmbiguousCaseException] {
-	  normalise(meta, None)
+    Feature("meta1", Nil), None, List(
+      Scenario(Set[Tag]("@StepDef"), "stepdef1", None, List(
+        Step(StepKeyword.Given, "step 1", Passed(2)),
+        Step(StepKeyword.When, "step 2", Passed(1)),
+        Step(StepKeyword.Then, "step 3", Passed(2)))
+      ),
+      Scenario(Set[Tag]("@StepDef"), "stepdef1", None, List(
+        Step(StepKeyword.Given, "step 1", Passed(2)),
+        Step(StepKeyword.When, "step 2", Passed(1)),
+        Step(StepKeyword.Then, "step 3", Passed(2)))
+      )))
+      
+  intercept[AmbiguousCaseException] {
+    normalise(meta, None)
     }
   }
   

--- a/src/test/scala/gwen/dsl/SpecNormaliserTest.scala
+++ b/src/test/scala/gwen/dsl/SpecNormaliserTest.scala
@@ -93,8 +93,8 @@ class SpecNormaliserTest extends FlatSpec with Matchers with SpecNormaliser {
         Step(StepKeyword.Then, "step 3", Passed(2)))
       )))
       
-  intercept[AmbiguousCaseException] {
-    normalise(meta, None)
+    intercept[AmbiguousCaseException] {
+      normalise(meta, None)
     }
   }
   

--- a/src/test/scala/gwen/eval/EnvContextTest.scala
+++ b/src/test/scala/gwen/eval/EnvContextTest.scala
@@ -63,6 +63,19 @@ class EnvContextTest extends FlatSpec with Matchers {
     
   }
   
+  "StepDef with params" should "resolve" in {
+    
+    val stepdef1 = Scenario(Set(Tag("StepDef")), """I enter "<searchTerm>" in the search field""", None, Nil)
+    val stepdef2 = Scenario(Set(Tag("StepDef")), """I enter "<search term>" in the search field again""", None, Nil)
+    val env = newEnv
+    env.addStepDef(stepdef1)
+    env.addStepDef(stepdef2)
+    
+    env.getStepDefWithParams("""I enter "gwen" in the search field""") should be (Some(stepdef1))
+    env.getStepDefWithParams("""I enter "gwen" in the search field again""") should be (Some(stepdef2))
+    
+  }
+  
   "New feature env context" should "have global feature scope" in {
     val env = newEnv
     env.featureScope.scope should be ("feature")

--- a/src/test/scala/gwen/eval/EnvContextTest.scala
+++ b/src/test/scala/gwen/eval/EnvContextTest.scala
@@ -67,12 +67,22 @@ class EnvContextTest extends FlatSpec with Matchers {
     
     val stepdef1 = Scenario(Set(Tag("StepDef")), """I enter "<searchTerm>" in the search field""", None, Nil)
     val stepdef2 = Scenario(Set(Tag("StepDef")), """I enter "<search term>" in the search field again""", None, Nil)
+    val stepdef3 = Scenario(Set(Tag("StepDef")), "z = <x> + 1", None, Nil)
+    val stepdef4 = Scenario(Set(Tag("StepDef")), "z = 1 + <x>", None, Nil)
+    val stepdef5 = Scenario(Set(Tag("StepDef")), "z = <x> - <y>", None, Nil)
+    
     val env = newEnv
     env.addStepDef(stepdef1)
     env.addStepDef(stepdef2)
+    env.addStepDef(stepdef3)
+    env.addStepDef(stepdef4)
+    env.addStepDef(stepdef5)
     
     env.getStepDefWithParams("""I enter "gwen" in the search field""") should be (Some(stepdef1))
     env.getStepDefWithParams("""I enter "gwen" in the search field again""") should be (Some(stepdef2))
+    env.getStepDefWithParams("z = 2 + 1") should be (Some(stepdef3))
+    env.getStepDefWithParams("z = 1 + 3") should be (Some(stepdef4))
+    env.getStepDefWithParams("z = 2 - 2") should be (Some(stepdef5))
     
   }
   

--- a/src/test/scala/gwen/eval/LocalDataStackTest.scala
+++ b/src/test/scala/gwen/eval/LocalDataStackTest.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2014 Branko Juric, Brady Wood
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gwen.eval
+
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers
+
+import gwen.errors.UnboundAttributeException
+
+class LocalDataStackTest extends FlatSpec with Matchers {
+
+  "get" should "throw error when there is not data" in {
+    
+    val localData = new LocalDataStack()
+    
+    intercept[UnboundAttributeException] { localData.get("username") }
+    intercept[UnboundAttributeException] { localData.get("password") }
+    intercept[UnboundAttributeException] { localData.get("firstName") }
+    intercept[UnboundAttributeException] { localData.get("lastName") }
+  }
+  
+  "get" should "get visible local data" in {
+    
+    val localData = new LocalDataStack()
+    
+    localData.push("login", List(("username", "gwen"), ("password", "pwd")))
+    localData.push("register", List(("password", "secret")))
+    
+    localData.get("username")  should be ("gwen")
+    localData.get("password")   should be ("secret")
+    
+    localData.pop
+    
+    localData.get("username")  should be ("gwen")
+    localData.get("password")   should be ("pwd")
+    
+  }
+  
+}

--- a/src/test/scala/gwen/eval/support/InterpolationSupportTest.scala
+++ b/src/test/scala/gwen/eval/support/InterpolationSupportTest.scala
@@ -21,31 +21,61 @@ import org.scalatest.Matchers
 
 class InterpolationSupportTest extends FlatSpec with Matchers with InterpolationSupport {
 
-  """interpolate using property syntax: prefix "${binding}"""" should "resolve" in {
-    interpolate("""hello "${binding}"""") { binding => "you" } should be ("""hello "you"""") 
+  """interpolate using property syntax: prefix "${property}"""" should "resolve" in {
+    interpolate("""hello "${property}"""") { property => "you" } should be ("""hello "you"""") 
   }
   
-  """interpolate using property syntax: prefix ${binding}""" should "resolve" in {
-    interpolate("""hello ${binding}""") { binding => "you" } should be ("""hello you""") 
+  """interpolate using property syntax: prefix ${property}""" should "resolve" in {
+    interpolate("""hello ${property}""") { property => "you" } should be ("""hello you""") 
   }
   
-  """interpolate using property syntax: "${binding}" suffix""" should "resolve" in {
-    interpolate(""""${binding}" you""") { binding => "hello" } should be (""""hello" you""") 
+  """interpolate using property syntax: "${property}" suffix""" should "resolve" in {
+    interpolate(""""${property}" you""") { property => "hello" } should be (""""hello" you""") 
   }
   
-  """interpolate using property syntax: ${binding} "suffix"""" should "resolve" in {
-    interpolate("""${binding} "you"""") { binding => "hello" } should be ("""hello "you"""") 
+  """interpolate using property syntax: ${property} "suffix"""" should "resolve" in {
+    interpolate("""${property} "you"""") { property => "hello" } should be ("""hello "you"""") 
   }
   
-  """interpolate using property syntax: prefix ${binding} suffix""" should "resolve" in {
-    interpolate("""hello ${binding} good thing""") { binding => "you" } should be ("""hello you good thing""") 
+  """interpolate using property syntax: prefix ${property} suffix""" should "resolve" in {
+    interpolate("""hello ${property} good thing""") { property => "you" } should be ("""hello you good thing""") 
   }
   
-  """interpolate nested using property syntax: ${binding1${binding0}}"""" should "resolve" in {
-    interpolate("""Hey you ${binding-${id}} thing!""") { binding => 
-      binding match {
+  """interpolate nested using property syntax: ${property1-${property0}}"""" should "resolve" in {
+    interpolate("""Hey you ${property-${id}} thing!""") { property => 
+      property match {
         case "id" => "0"
-        case "binding-0" => "good"
+        case "property-0" => "good"
+        case _ => "undefined"
+      }
+    } should be ("""Hey you good thing!""") 
+  }
+  
+  """interpolate using stepdef param syntax: prefix "$<param>"""" should "resolve" in {
+    interpolate("""hello "$<param>"""") { param => "you" } should be ("""hello "you"""") 
+  }
+  
+  """interpolate using stepdef param syntax: prefix $<param>""" should "resolve" in {
+    interpolate("""hello $<param>""") { param => "you" } should be ("""hello you""") 
+  }
+  
+  """interpolate using stepdef param syntax: "$<param>" suffix""" should "resolve" in {
+    interpolate(""""$<param>" you""") { param => "hello" } should be (""""hello" you""") 
+  }
+  
+  """interpolate using stepdef param syntax: $<param> "suffix"""" should "resolve" in {
+    interpolate("""$<param> "you"""") { param => "hello" } should be ("""hello "you"""") 
+  }
+  
+  """interpolate using stepdef param syntax: prefix $<param> suffix""" should "resolve" in {
+    interpolate("""hello $<param> good thing""") { param => "you" } should be ("""hello you good thing""") 
+  }
+  
+  """interpolate nested using stepdef param syntax: $<param1-$<param0>>"""" should "resolve" in {
+    interpolate("""Hey you $<param-$<id>> thing!""") { param => 
+      param match {
+        case "<id>" => "0"
+        case "<param-0>" => "good"
         case _ => "undefined"
       }
     } should be ("""Hey you good thing!""") 

--- a/src/test/scala/gwen/sample/math/MathInterpreter.scala
+++ b/src/test/scala/gwen/sample/math/MathInterpreter.scala
@@ -57,9 +57,14 @@ trait MathEvalEngine extends EvalEngine[MathEnvContext] {
           logger.info(s"evaluating z = $xvalue + $yvalue")
           val zresult = env.mathService.plus(xvalue, yvalue)
           vars.set("z", zresult.toString)
+        } getOrElse {
+          vars.set("z", "0")
         }
       case r"([a-z])$x == (\d+)$value" =>
-        assert (vars.get(x).toInt == value.toInt)
+        val xvalue = vars.get(x).toInt
+        env.execute {
+          assert (xvalue.toInt == value.toInt)
+        }
       case _ =>
         super.evaluate(step, env)
     }

--- a/src/test/scala/gwen/sample/math/MathInterpreterTest.scala
+++ b/src/test/scala/gwen/sample/math/MathInterpreterTest.scala
@@ -28,6 +28,23 @@ class MathInterpreterTest extends FlatSpec {
     }
   }
   
+  "math features" should "pass --dry-run test" in {
+    
+    val options = GwenOptions(
+      batch = true,
+      reportDir = Some(new File("target/report")), 
+      features = List(new File("features/sample/math")),
+      dryRun = true
+    )
+      
+    val launcher = new GwenLauncher(new MathInterpreter())
+    launcher.run(options, None) match {
+      case Passed(_) => // excellent :)
+      case Failed(_, error) => error.printStackTrace(); fail(error.getMessage())
+      case _ => fail("evaluation expected but got noop")
+    }
+  }
+  
   "math.dsl" should "pass --dry-run test" in {
     
     val options = new GwenOptions(dryRun = true);


### PR DESCRIPTION
Implemented support for StepDef parameters. Parameters can now be passed inline instead of through other attributes. 

Parameters are declared in StepDefs using the ```<name>``` syntax and dereferenced with ```$<name>```

For example, the following StepDef can be used to assert that you should be on a page 

```
@StepDef
Scenario: I should be on the <page name> page
    Given I wait until the heading is displayed
     Then I am on the $<page name> page
      And the heading should be "$<page name>"
```
   
Once defined in meta, features can then call it to assert that they are on specific pages as follows:

```
Then I should be on the Step 2 page
Then I should be on the Step 3 page
Then I should be on the Dashboard page
```

This feature will help eliminate a lot of redundancies and make composing custom DSLs much easier.

