### PR TITLE
Feature/junit xml reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Key Features
 - Gherkin feature parser
 - Abstract evaluation engine
 - REPL console
-- Evaluation reports
+- Evaluation reports (Pretty HTML and JUnit-XML)
 - Data scopes
 - Meta features
 - Composable step definitions (@StepDef's)
@@ -137,7 +137,9 @@ Evaluation Reports
 
 Gwen reports all evaluated results to the system output stream. Pretty HTML 
 reports containing detailed results, statistics, and summaries can also be 
-generated and written to the file system.
+generated and written to the file system. JUnit-XML reports are also 
+generated alongside the top level HTML reports directory for easy integration 
+with build servers.  
 
 ![Gwen Evaluation Report](doc/img/gwen-report.png)  
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Key Features
 - Gherkin feature parser
 - Abstract evaluation engine
 - REPL console
-- Evaluation reports (Pretty HTML and JUnit-XML)
+- Evaluation reports (Rich HTML and JUnit-XML)
 - Data scopes
 - Meta features
 - Composable step definitions (@StepDef's)
@@ -137,9 +137,8 @@ Evaluation Reports
 
 Gwen reports all evaluated results to the system output stream. Pretty HTML 
 reports containing detailed results, statistics, and summaries can also be 
-generated and written to the file system. JUnit-XML reports are also 
-generated alongside the top level HTML reports directory for easy integration 
-with build servers.  
+generated and written to the file system. JUnit XML reports can also 
+be optionally generated for easy integration with most build servers.  
 
 ![Gwen Evaluation Report](doc/img/gwen-report.png)  
 

--- a/doc/START.md
+++ b/doc/START.md
@@ -833,6 +833,9 @@ Usage: scala gwen.sample.math.MathInterpreter [options] [<features>]
         Comma separated list of properties file paths
   -r <report directory> | --report <report directory>
         Evaluation report output directory
+  -f <formats> | --formats <formats>
+        Comma separated list of report formats to produce	
+         - Supported formats include: html,junit (default is html)
   -t <tags> | --tags <tags>
         Comma separated list of @include or ~@exclude tags
   -n | --dry-run

--- a/src/main/resources/gwen/report/html/index.html
+++ b/src/main/resources/gwen/report/html/index.html
@@ -2,13 +2,13 @@
 <html lang="en-US">
     <head>
         <meta charset="UTF-8">
-        <meta http-equiv="refresh" content="1;url=feature-summary.html">
+        <meta http-equiv="refresh" content="1;url=html/feature-summary.html">
         <script type="text/javascript">
-            window.location.href = "feature-summary.html"
+            window.location.href = "html/feature-summary.html"
         </script>
         <title>Page Redirection</title>
     </head>
     <body>
-        If you are not redirected automatically, follow the <a href='feature-summary.html'>link to the report</a>.
+        If you are not redirected automatically, follow the <a href='html/feature-summary.html'>link to the report</a>.
     </body>
 </html>

--- a/src/main/scala/gwen/Predefs.scala
+++ b/src/main/scala/gwen/Predefs.scala
@@ -97,7 +97,10 @@ object Predefs extends LazyLogging {
     }
     
     def toDir(targetDir: File, targetSubDir: Option[String]): File =
-      new File(Path(targetDir.getPath() + File.separator + FileIO.encodeDir(file.getParent()) + targetSubDir.map(File.separator + _).getOrElse("")).createDirectory().path)
+      new File(Path(toPath(targetDir, targetSubDir)).createDirectory().path)
+    
+    def toPath(targetDir: File, targetSubDir: Option[String]): String =
+      targetDir.getPath() + File.separator + FileIO.encodeDir(file.getParent()) + targetSubDir.map(File.separator + _).getOrElse("")
     
     def toFile(targetDir: File, targetSubDir: Option[String]): File =
       new File(toDir(targetDir, targetSubDir), file.getName())

--- a/src/main/scala/gwen/eval/FeatureSummary.scala
+++ b/src/main/scala/gwen/eval/FeatureSummary.scala
@@ -83,8 +83,8 @@ case class FeatureSummary(
 /** Feature summary factory. */
 object FeatureSummary {
   def apply(): FeatureSummary = new FeatureSummary(Nil, Map(), Map())
-  def apply(spec: FeatureSpec, report: Option[File]): FeatureSummary =
-    FeatureSummary() + FeatureResult(spec, report, Nil)
+  def apply(spec: FeatureSpec, reports: Option[Map[String, File]]): FeatureSummary =
+    FeatureSummary() + FeatureResult(spec, reports, Nil)
   def apply(result: FeatureResult): FeatureSummary = FeatureSummary() + result
 }
 
@@ -94,31 +94,31 @@ case class FeatureSummaryLine(
   featureName: String, 
   featureFile: Option[File], 
   evalStatus: EvalStatus, 
-  report: Option[File])
+  reports: Option[Map[String, File]])
 
 /**
   * Captures the results of an evaluated feature.
   * 
   * @param spec the evaluated feature
   * @param metaResults the evaluated meta results
-  * @param report the report file
+  * @param reports optional map of report files (keyed by report type)
   */
 class FeatureResult(
   val spec: FeatureSpec, 
-  val report: Option[File], 
+  val reports: Option[Map[String, File]], 
   val metaResults: List[FeatureResult]) {
   
   val timestamp = new Date()
   val screenshots = spec.steps.flatMap(_.attachments).filter(_._1 == "Screenshot").map(_._2)
   val isMeta = spec.featureFile.map(_.getName().endsWith(".meta")).getOrElse(false)
-  def summaryLine = new FeatureSummaryLine(timestamp, spec.feature.name, spec.featureFile, spec.evalStatus, report)
+  def summaryLine = new FeatureSummaryLine(timestamp, spec.feature.name, spec.featureFile, spec.evalStatus, reports)
   def summary = FeatureSummary(this)
   
 }
 
 /** Feature result factory. */
 object FeatureResult {
-  def apply(spec: FeatureSpec, report: Option[File], metaResults: List[FeatureResult]): FeatureResult = 
-    new FeatureResult(spec, report, metaResults)
+  def apply(spec: FeatureSpec, reports: Option[Map[String, File]], metaResults: List[FeatureResult]): FeatureResult = 
+    new FeatureResult(spec, reports, metaResults)
 }
 

--- a/src/main/scala/gwen/eval/FeatureSummary.scala
+++ b/src/main/scala/gwen/eval/FeatureSummary.scala
@@ -24,6 +24,7 @@ import gwen.dsl.Tag
 import java.io.File
 import gwen.dsl.EvalStatus
 import gwen.dsl.Passed
+import gwen.report.ReportFormat
 
 /**
   * Captures the feature summary results of an evaluated feature.
@@ -83,7 +84,7 @@ case class FeatureSummary(
 /** Feature summary factory. */
 object FeatureSummary {
   def apply(): FeatureSummary = new FeatureSummary(Nil, Map(), Map())
-  def apply(spec: FeatureSpec, reports: Option[Map[String, File]]): FeatureSummary =
+  def apply(spec: FeatureSpec, reports: Option[Map[ReportFormat.Value, File]]): FeatureSummary =
     FeatureSummary() + FeatureResult(spec, reports, Nil)
   def apply(result: FeatureResult): FeatureSummary = FeatureSummary() + result
 }
@@ -94,7 +95,7 @@ case class FeatureSummaryLine(
   featureName: String, 
   featureFile: Option[File], 
   evalStatus: EvalStatus, 
-  reports: Option[Map[String, File]])
+  reports: Option[Map[ReportFormat.Value, File]])
 
 /**
   * Captures the results of an evaluated feature.
@@ -105,7 +106,7 @@ case class FeatureSummaryLine(
   */
 class FeatureResult(
   val spec: FeatureSpec, 
-  val reports: Option[Map[String, File]], 
+  val reports: Option[Map[ReportFormat.Value, File]], 
   val metaResults: List[FeatureResult]) {
   
   val timestamp = new Date()
@@ -118,7 +119,7 @@ class FeatureResult(
 
 /** Feature result factory. */
 object FeatureResult {
-  def apply(spec: FeatureSpec, reports: Option[Map[String, File]], metaResults: List[FeatureResult]): FeatureResult = 
+  def apply(spec: FeatureSpec, reports: Option[Map[ReportFormat.Value, File]], metaResults: List[FeatureResult]): FeatureResult = 
     new FeatureResult(spec, reports, metaResults)
 }
 

--- a/src/main/scala/gwen/eval/GwenLauncher.scala
+++ b/src/main/scala/gwen/eval/GwenLauncher.scala
@@ -16,20 +16,17 @@
 
 package gwen.eval
 
-import java.io.File
 import scala.Option.option2Iterable
+
+import com.typesafe.scalalogging.slf4j.LazyLogging
+
 import gwen.ConsoleWriter
 import gwen.Predefs.Kestrel
-import gwen.Predefs.FileIO
 import gwen.UserOverrides
 import gwen.dsl.EvalStatus
 import gwen.dsl.Failed
-import gwen.report.ReportGenerator
-import gwen.report.html.HtmlReportGenerator
-import gwen.GwenInfo
 import gwen.dsl.FeatureSpec
-import com.typesafe.scalalogging.slf4j.LazyLogging
-import gwen.report.junit.JUnitReportGenerator
+import gwen.report.ReportGenerator
 
 /**
   * Launches the gwen interpreter.
@@ -87,9 +84,7 @@ class GwenLauncher[T <: EnvContext](interpreter: GwenInterpreter[T]) extends Laz
     *               otherwise a new context is created for each unit)
     */
   private def executeFeatureUnits(options: GwenOptions, featureStream: Stream[FeatureUnit], envOpt: Option[T]): FeatureSummary = {
-    val reportGenerators = options.reportDir map { _ =>
-      List(new HtmlReportGenerator(options), new JUnitReportGenerator(options))
-    } getOrElse(Nil)
+    val reportGenerators = ReportGenerator.generatorsFor(options)
     if (options.parallel) {
       val results = featureStream.par.flatMap { unit =>
         evaluateUnit(options, envOpt, unit) { specs => 

--- a/src/main/scala/gwen/eval/GwenLauncher.scala
+++ b/src/main/scala/gwen/eval/GwenLauncher.scala
@@ -20,6 +20,7 @@ import java.io.File
 import scala.Option.option2Iterable
 import gwen.ConsoleWriter
 import gwen.Predefs.Kestrel
+import gwen.Predefs.FileIO
 import gwen.UserOverrides
 import gwen.dsl.EvalStatus
 import gwen.dsl.Failed
@@ -28,6 +29,7 @@ import gwen.report.html.HtmlReportGenerator
 import gwen.GwenInfo
 import gwen.dsl.FeatureSpec
 import com.typesafe.scalalogging.slf4j.LazyLogging
+import gwen.report.junit.JUnitReportGenerator
 
 /**
   * Launches the gwen interpreter.
@@ -85,20 +87,20 @@ class GwenLauncher[T <: EnvContext](interpreter: GwenInterpreter[T]) extends Laz
     *               otherwise a new context is created for each unit)
     */
   private def executeFeatureUnits(options: GwenOptions, featureStream: Stream[FeatureUnit], envOpt: Option[T]): FeatureSummary = {
-    val reportGenerator = options.reportDir map { reportDir =>
-      new HtmlReportGenerator(options)
-    }
+    val reportGenerators = options.reportDir map { _ =>
+      List(new HtmlReportGenerator(options), new JUnitReportGenerator(options))
+    } getOrElse(Nil)
     if (options.parallel) {
       val results = featureStream.par.flatMap { unit =>
         evaluateUnit(options, envOpt, unit) { specs => 
           specs match { 
             case Nil => None
-            case _ => Some(toFeatureResult(reportGenerator, specs, unit.dataRecord))
+            case _ => Some(toFeatureResult(reportGenerators, specs, unit.dataRecord))
           }
         }
       }
       results.toList.sortBy(_.timestamp).foldLeft(FeatureSummary()) (_+_) tap { summary => 
-        reportGenerator foreach { _.reportSummary(interpreter, summary) }
+        reportGenerators foreach { _.reportSummary(interpreter, summary) }
       }
     } else {
       featureStream.foldLeft(FeatureSummary()) { (summary, unit) =>
@@ -106,10 +108,10 @@ class GwenLauncher[T <: EnvContext](interpreter: GwenInterpreter[T]) extends Laz
           specs match { 
             case Nil => summary
             case specs => 
-              val result = toFeatureResult(reportGenerator, specs, unit.dataRecord)
+              val result = toFeatureResult(reportGenerators, specs, unit.dataRecord)
               summary + result tap { accSummary =>
                 if (!options.parallel) {
-                  reportGenerator foreach { _.reportSummary(interpreter, accSummary) }
+                  reportGenerators foreach { _.reportSummary(interpreter, accSummary) }
                 }
               }
           }
@@ -139,13 +141,15 @@ class GwenLauncher[T <: EnvContext](interpreter: GwenInterpreter[T]) extends Laz
     }
   }
     
-  private def toFeatureResult(reportGenerator: Option[ReportGenerator], specs: List[FeatureSpec], dataRecord: Option[DataRecord]): FeatureResult = 
-    reportGenerator.map(_.reportDetail(interpreter, specs, dataRecord)).getOrElse(FeatureResult(specs.head, None, specs.map(FeatureResult(_, None, Nil)))) tap { result =>
+  private def toFeatureResult(reportGenerators: List[ReportGenerator], specs: List[FeatureSpec], dataRecord: Option[DataRecord]): FeatureResult = {
+    val reportFiles = reportGenerators.flatMap(_.reportDetail(interpreter, specs, dataRecord)).map(f => (f.extension -> f)).toMap
+    FeatureResult(specs.head, if (reportFiles.nonEmpty) Some(reportFiles) else None, specs.tail.map(FeatureResult(_, None, Nil))) tap { result => 
       val status = result.spec.evalStatus
-      logger.info("");
+      logger.info("")
       logger.info(s"${status} ${result.timestamp} ${status.emoticon}", status)
-      logger.info("");
+      logger.info("")
     }
+  }
   
   private def printSummaryStatus(summary: FeatureSummary) {
     println

--- a/src/main/scala/gwen/eval/GwenLauncher.scala
+++ b/src/main/scala/gwen/eval/GwenLauncher.scala
@@ -142,7 +142,7 @@ class GwenLauncher[T <: EnvContext](interpreter: GwenInterpreter[T]) extends Laz
   }
     
   private def toFeatureResult(reportGenerators: List[ReportGenerator], specs: List[FeatureSpec], dataRecord: Option[DataRecord]): FeatureResult = {
-    val reportFiles = reportGenerators.flatMap(_.reportDetail(interpreter, specs, dataRecord)).map(f => (f.extension -> f)).toMap
+    val reportFiles = reportGenerators.flatMap(_.reportDetail(interpreter, specs, dataRecord)).toMap
     FeatureResult(specs.head, if (reportFiles.nonEmpty) Some(reportFiles) else None, specs.tail.map(FeatureResult(_, None, Nil))) tap { result => 
       val status = result.spec.evalStatus
       logger.info("")

--- a/src/main/scala/gwen/report/ReportFormat.scala
+++ b/src/main/scala/gwen/report/ReportFormat.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2015 Branko Juric, Brady Wood
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gwen.report
+
+import scala.language.implicitConversions
+import scala.language.postfixOps
+import gwen.report.html.HtmlReportGenerator
+import gwen.eval.GwenOptions
+import gwen.report.junit.JUnitReportGenerator
+import java.io.File
+
+/**
+  * Enumeration of supported report formats.
+  * 
+  * @author Branko Juric
+  */
+object ReportFormat extends Enumeration {
+
+  val html, junit = Value
+  
+  class FormatValue(
+      val name: String, 
+      val fileExtension: String, 
+      val summaryFilename: Option[String], 
+      getGenerator: GwenOptions => ReportGenerator, 
+      getReportDir: GwenOptions => File) {
+    def reportGenerator(options: GwenOptions): ReportGenerator = getGenerator(options)
+    def reportDir(options: GwenOptions): File = getReportDir(options)
+  }
+  
+  private val Values = Map(
+    html -> new FormatValue(
+        "HTML", 
+        "html", 
+        Some("feature-summary"), 
+        options => new HtmlReportGenerator(options), 
+        options => options.reportDir.map(new File(_, "html")).get),
+    junit -> new FormatValue(
+        "JUnit-XML", 
+        "xml", 
+        None, 
+        options => new JUnitReportGenerator(options), 
+        options => options.reportDir.map(new File(_, "junit")).get)
+  )
+  
+  implicit def value2ReportFormat(value: Value) = Values(value)
+  
+}
+

--- a/src/main/scala/gwen/report/ReportFormatter.scala
+++ b/src/main/scala/gwen/report/ReportFormatter.scala
@@ -43,10 +43,4 @@ trait ReportFormatter {
     */
   def formatSummary(options: GwenOptions, info: GwenInfo, summary: FeatureSummary): Option[String]
   
-  /** Defines file extension for format. */
-  def formatExtension: String
-  
-  /** Defines format name. */
-  def formatName: String
-  
 }

--- a/src/main/scala/gwen/report/ReportFormatter.scala
+++ b/src/main/scala/gwen/report/ReportFormatter.scala
@@ -41,6 +41,6 @@ trait ReportFormatter {
     * @param info the gwen implementation info
     * @param summary the accumulated feature results summary
     */
-  def formatSummary(options: GwenOptions, info: GwenInfo, summary: FeatureSummary): String
+  def formatSummary(options: GwenOptions, info: GwenInfo, summary: FeatureSummary): Option[String]
   
 }

--- a/src/main/scala/gwen/report/ReportFormatter.scala
+++ b/src/main/scala/gwen/report/ReportFormatter.scala
@@ -43,4 +43,10 @@ trait ReportFormatter {
     */
   def formatSummary(options: GwenOptions, info: GwenInfo, summary: FeatureSummary): Option[String]
   
+  /** Defines file extension for format. */
+  def formatExtension: String
+  
+  /** Defines format name. */
+  def formatName: String
+  
 }

--- a/src/main/scala/gwen/report/html/HtmlReportFormatter.scala
+++ b/src/main/scala/gwen/report/html/HtmlReportFormatter.scala
@@ -63,7 +63,7 @@ trait HtmlReportFormatter extends ReportFormatter {
     val status = result.spec.evalStatus.status
     val summary = result.summary
     val screenshots = result.screenshots
-    val rootPath = relativePath(result.report.get, options.reportDir.get).filter(_ == File.separatorChar).flatMap(c => "../")
+    val rootPath = relativePath(result.reports.get("html"), options.reportDir.get).filter(_ == File.separatorChar).flatMap(c => "../")
     
     s"""<!DOCTYPE html>
 <html lang="en">
@@ -125,7 +125,7 @@ trait HtmlReportFormatter extends ReportFormatter {
         <ul class="list-group">
           <li class="list-group-item list-group-item-${cssStatus(status)}">
             <div class="container-fluid" style="padding: 0px 0px">
-              ${(metaResults.zipWithIndex map { case (result, rowIndex) => formatSummaryLine(result.summaryLine, s"meta/${result.report.get.getName()}", None, rowIndex)}).mkString}
+              ${(metaResults.zipWithIndex map { case (result, rowIndex) => formatSummaryLine(result.summaryLine, s"meta/${result.reports.get("html").getName()}", None, rowIndex)}).mkString}
             </div>
           </li>
         </ul>
@@ -184,12 +184,12 @@ trait HtmlReportFormatter extends ReportFormatter {
     * @param info the gwen implementation info
     * @param summary the accumulated feature results summary
     */
-  override def formatSummary(options: GwenOptions, info: GwenInfo, summary: FeatureSummary): String = {
+  override def formatSummary(options: GwenOptions, info: GwenInfo, summary: FeatureSummary): Option[String] = {
     
     val title = "Feature Summary";
     val status = summary.evalStatus.status
   
-    s"""<!DOCTYPE html>
+    Some(s"""<!DOCTYPE html>
 <html lang="en">
   <head>
     ${formatHtmlHead(title, "")}
@@ -240,7 +240,7 @@ trait HtmlReportFormatter extends ReportFormatter {
           <li class="list-group-item list-group-item-${cssStatus(status)}">
             <div class="container-fluid" style="padding: 0px 0px">${
                 (results.zipWithIndex map { case ((result, resultIndex), rowIndex) => 
-                  val report = result.report.get
+                  val report = result.reports.get("html")
                   formatSummaryLine(result, s"${relativePath(report, options.reportDir.get).replace(File.separatorChar, '/')}", Some(resultIndex + 1), rowIndex)
                 }).mkString}
             </div>
@@ -250,7 +250,7 @@ trait HtmlReportFormatter extends ReportFormatter {
     </div>"""}}).mkString}
   </body>
 </html>
-    """
+    """)
   }
   
   private def formatHtmlHead(title: String, rootPath: String) = s"""

--- a/src/main/scala/gwen/report/html/HtmlReportFormatter.scala
+++ b/src/main/scala/gwen/report/html/HtmlReportFormatter.scala
@@ -34,9 +34,12 @@ import gwen.dsl.Scenario
 import gwen.dsl.Tag
 import gwen.Settings
 import gwen.GwenSettings
+import gwen.report.ReportFormat
 
 /** Formats the feature summary and detail reports in HTML. */
 trait HtmlReportFormatter extends ReportFormatter {
+  
+  private val reportFormat = ReportFormat.html
   
   private val cssStatus = Map(
       StatusKeyword.Passed -> "success", 
@@ -47,9 +50,6 @@ trait HtmlReportFormatter extends ReportFormatter {
   
   private val percentFormatter = new DecimalFormat("#.##")
   
-  override def formatExtension: String = "html"
-  override def formatName: String = "HTML"
-
   /**
     * Formats the feature detail report as HTML.
     * 
@@ -60,13 +60,14 @@ trait HtmlReportFormatter extends ReportFormatter {
     */
   override def formatDetail(options: GwenOptions, info: GwenInfo, result: FeatureResult, breadcrumbs: List[(String, File)]): String = {
     
+    val reportDir = reportFormat.reportDir(options)
     val metaResults = result.metaResults 
     val featureName = result.spec.featureFile.map(_.getPath()).getOrElse(result.spec.feature.name)
     val title = s"${if(result.isMeta) "Meta" else "Feature"} Detail"
     val status = result.spec.evalStatus.status
     val summary = result.summary
     val screenshots = result.screenshots
-    val rootPath = relativePath(result.reports.get(formatName), options.reportDir.get).filter(_ == File.separatorChar).flatMap(c => "../")
+    val rootPath = relativePath(result.reports.get(reportFormat), reportDir).filter(_ == File.separatorChar).flatMap(c => "../")
     
     s"""<!DOCTYPE html>
 <html lang="en">
@@ -128,7 +129,7 @@ trait HtmlReportFormatter extends ReportFormatter {
         <ul class="list-group">
           <li class="list-group-item list-group-item-${cssStatus(status)}">
             <div class="container-fluid" style="padding: 0px 0px">
-              ${(metaResults.zipWithIndex map { case (result, rowIndex) => formatSummaryLine(result.summaryLine, s"meta/${result.reports.get(formatName).getName()}", None, rowIndex)}).mkString}
+              ${(metaResults.zipWithIndex map { case (result, rowIndex) => formatSummaryLine(result.summaryLine, s"meta/${result.reports.get(reportFormat).getName()}", None, rowIndex)}).mkString}
             </div>
           </li>
         </ul>
@@ -189,6 +190,7 @@ trait HtmlReportFormatter extends ReportFormatter {
     */
   override def formatSummary(options: GwenOptions, info: GwenInfo, summary: FeatureSummary): Option[String] = {
     
+    val reportDir = reportFormat.reportDir(options)
     val title = "Feature Summary";
     val status = summary.evalStatus.status
   
@@ -243,8 +245,8 @@ trait HtmlReportFormatter extends ReportFormatter {
           <li class="list-group-item list-group-item-${cssStatus(status)}">
             <div class="container-fluid" style="padding: 0px 0px">${
                 (results.zipWithIndex map { case ((result, resultIndex), rowIndex) => 
-                  val report = result.reports.get(formatName)
-                  formatSummaryLine(result, s"${relativePath(report, options.reportDir.get).replace(File.separatorChar, '/')}", Some(resultIndex + 1), rowIndex)
+                  val report = result.reports.get(reportFormat)
+                  formatSummaryLine(result, s"${relativePath(report, reportDir).replace(File.separatorChar, '/')}", Some(resultIndex + 1), rowIndex)
                 }).mkString}
             </div>
           </li>

--- a/src/main/scala/gwen/report/html/HtmlReportFormatter.scala
+++ b/src/main/scala/gwen/report/html/HtmlReportFormatter.scala
@@ -46,6 +46,9 @@ trait HtmlReportFormatter extends ReportFormatter {
       StatusKeyword.Loaded -> "success")
   
   private val percentFormatter = new DecimalFormat("#.##")
+  
+  override def formatExtension: String = "html"
+  override def formatName: String = "HTML"
 
   /**
     * Formats the feature detail report as HTML.
@@ -63,7 +66,7 @@ trait HtmlReportFormatter extends ReportFormatter {
     val status = result.spec.evalStatus.status
     val summary = result.summary
     val screenshots = result.screenshots
-    val rootPath = relativePath(result.reports.get("html"), options.reportDir.get).filter(_ == File.separatorChar).flatMap(c => "../")
+    val rootPath = relativePath(result.reports.get(formatName), options.reportDir.get).filter(_ == File.separatorChar).flatMap(c => "../")
     
     s"""<!DOCTYPE html>
 <html lang="en">
@@ -125,7 +128,7 @@ trait HtmlReportFormatter extends ReportFormatter {
         <ul class="list-group">
           <li class="list-group-item list-group-item-${cssStatus(status)}">
             <div class="container-fluid" style="padding: 0px 0px">
-              ${(metaResults.zipWithIndex map { case (result, rowIndex) => formatSummaryLine(result.summaryLine, s"meta/${result.reports.get("html").getName()}", None, rowIndex)}).mkString}
+              ${(metaResults.zipWithIndex map { case (result, rowIndex) => formatSummaryLine(result.summaryLine, s"meta/${result.reports.get(formatName).getName()}", None, rowIndex)}).mkString}
             </div>
           </li>
         </ul>
@@ -240,7 +243,7 @@ trait HtmlReportFormatter extends ReportFormatter {
           <li class="list-group-item list-group-item-${cssStatus(status)}">
             <div class="container-fluid" style="padding: 0px 0px">${
                 (results.zipWithIndex map { case ((result, resultIndex), rowIndex) => 
-                  val report = result.reports.get("html")
+                  val report = result.reports.get(formatName)
                   formatSummaryLine(result, s"${relativePath(report, options.reportDir.get).replace(File.separatorChar, '/')}", Some(resultIndex + 1), rowIndex)
                 }).mkString}
             </div>

--- a/src/main/scala/gwen/report/html/HtmlReportGenerator.scala
+++ b/src/main/scala/gwen/report/html/HtmlReportGenerator.scala
@@ -31,7 +31,7 @@ import gwen.eval.GwenOptions
   * @author Branko Juric
   */
 class HtmlReportGenerator(val options: GwenOptions) 
-  extends ReportGenerator(options, "feature-summary.html", "html", None) 
+  extends ReportGenerator(options, Some("feature-summary"), options.reportDir.get) 
   with HtmlReportFormatter {
 
   // copy in CSS files (if they don't already exist)

--- a/src/main/scala/gwen/report/html/HtmlReportGenerator.scala
+++ b/src/main/scala/gwen/report/html/HtmlReportGenerator.scala
@@ -31,7 +31,7 @@ import gwen.eval.GwenOptions
   * @author Branko Juric
   */
 class HtmlReportGenerator(val options: GwenOptions) 
-  extends ReportGenerator(options, "feature-summary", "html") 
+  extends ReportGenerator(options, "feature-summary.html", "html", None) 
   with HtmlReportFormatter {
 
   // copy in CSS files (if they don't already exist)

--- a/src/main/scala/gwen/report/html/HtmlReportGenerator.scala
+++ b/src/main/scala/gwen/report/html/HtmlReportGenerator.scala
@@ -23,6 +23,7 @@ import gwen.Predefs.Kestrel
 import gwen.report.ReportGenerator
 import gwen.GwenInfo
 import gwen.eval.GwenOptions
+import gwen.report.ReportFormat
 
 /**
   * Generates a HTML evaluation report. The report includes a feature
@@ -30,9 +31,7 @@ import gwen.eval.GwenOptions
   * 
   * @author Branko Juric
   */
-class HtmlReportGenerator(val options: GwenOptions) 
-  extends ReportGenerator(options, Some("feature-summary"), options.reportDir.get) 
-  with HtmlReportFormatter {
+class HtmlReportGenerator(val options: GwenOptions) extends ReportGenerator(ReportFormat.html, options) with HtmlReportFormatter {
 
   // copy in CSS files (if they don't already exist)
   new File(Path(new File(reportDir, "resources/css")).createDirectory().path) tap { dir =>
@@ -62,6 +61,6 @@ class HtmlReportGenerator(val options: GwenOptions)
   }
   
   // copy in index file
-  copyClasspathBinaryResourceToFile("/gwen/report/html/index.html", reportDir)
+  copyClasspathBinaryResourceToFile("/gwen/report/html/index.html", options.reportDir.get)
   
 }

--- a/src/main/scala/gwen/report/junit/JUnitReportFormatter.scala
+++ b/src/main/scala/gwen/report/junit/JUnitReportFormatter.scala
@@ -17,10 +17,8 @@ package gwen.report.html
 
 import java.io.File
 import java.net.InetAddress
-
 import org.joda.time.DateTime
 import org.joda.time.DateTimeZone
-
 import gwen.GwenInfo
 import gwen.Predefs.Exceptions
 import gwen.dsl.Failed
@@ -31,12 +29,10 @@ import gwen.eval.FeatureResult
 import gwen.eval.FeatureSummary
 import gwen.eval.GwenOptions
 import gwen.report.ReportFormatter
+import gwen.report.ReportFormat
 
 /** Formats the feature summary and detail reports in JUnit xml. */
 trait JUnitReportFormatter extends ReportFormatter {
-  
-  override def formatExtension: String = "xml"
-  override def formatName: String = "JUnit-XML"
   
   /**
     * Formats the feature detail report as HTML.

--- a/src/main/scala/gwen/report/junit/JUnitReportFormatter.scala
+++ b/src/main/scala/gwen/report/junit/JUnitReportFormatter.scala
@@ -16,33 +16,27 @@
 package gwen.report.html
 
 import java.io.File
-import java.text.DecimalFormat
-import java.util.Date
-import scala.concurrent.duration.Duration
-import gwen.dsl.DurationFormatter
-import gwen.dsl.EvalStatus
+import java.net.InetAddress
+
+import org.joda.time.DateTime
+import org.joda.time.DateTimeZone
+
+import gwen.GwenInfo
+import gwen.Predefs.Exceptions
 import gwen.dsl.Failed
+import gwen.dsl.Pending
+import gwen.dsl.Skipped
 import gwen.dsl.StatusKeyword
-import gwen.dsl.Step
 import gwen.eval.FeatureResult
 import gwen.eval.FeatureSummary
-import gwen.report.ReportFormatter
-import gwen.GwenInfo
 import gwen.eval.GwenOptions
-import gwen.eval.FeatureSummaryLine
-import gwen.dsl.Scenario
-import gwen.dsl.Tag
-import gwen.Settings
-import gwen.GwenSettings
-import java.net.InetAddress
-import org.joda.time.DateTimeZone
-import org.joda.time.DateTime
-import gwen.dsl.Failed
-import gwen.dsl.Skipped
-import gwen.dsl.Pending
+import gwen.report.ReportFormatter
 
 /** Formats the feature summary and detail reports in JUnit xml. */
 trait JUnitReportFormatter extends ReportFormatter {
+  
+  override def formatExtension: String = "xml"
+  override def formatName: String = "JUnit-XML"
   
   /**
     * Formats the feature detail report as HTML.
@@ -57,7 +51,7 @@ trait JUnitReportFormatter extends ReportFormatter {
     val scenarios = result.spec.scenarios.filter(!_.isStepDef)
     val hostname = s""" hostname="${InetAddress.getLocalHost.getHostName}""""
     val packageName = result.spec.featureFile.map(f => f.getPath()).getOrElse("")
-    val name = s""" name="${packageName}.${result.spec.feature.name}""""
+    val name = s""" name="${packageName}.Feature: ${result.spec.feature.name}""""
     val pkg = result.spec.featureFile.map(f => s""" package="${packageName}"""").getOrElse("")
     val scenarioCount = scenarios.length
     val tests = s""" tests="${scenarioCount}""""
@@ -73,10 +67,10 @@ trait JUnitReportFormatter extends ReportFormatter {
     <properties>${(sys.props.map { case (name, value) => s"""
         <property name="$name" value="$value"/>"""}).mkString}
     </properties>${(scenarios.map{scenario => s"""
-    <testcase name="${scenario.name}" time="${scenario.evalStatus.nanos.toDouble / 1000000000d}" status="${scenario.evalStatus.status}"${scenario.evalStatus match {
+    <testcase name="Scenario: ${scenario.name}" time="${scenario.evalStatus.nanos.toDouble / 1000000000d}" status="${scenario.evalStatus.status}"${scenario.evalStatus match {
     case Failed(_, error) => 
       s""">
-        <error type="${error.getClass().getName()}" message="${error.getMessage()}"/>
+        <error type="${error.getClass().getName()}" message="${error.writeStackTrace}"/>
     </testcase>"""
     case Skipped | Pending => 
       s""">

--- a/src/main/scala/gwen/report/junit/JUnitReportGenerator.scala
+++ b/src/main/scala/gwen/report/junit/JUnitReportGenerator.scala
@@ -27,6 +27,7 @@ import gwen.report.html.JUnitReportFormatter
 import gwen.dsl.FeatureSpec
 import gwen.eval.DataRecord
 import gwen.eval.FeatureResult
+import gwen.report.ReportFormat
 
 /**
   * Generates JUnit xml report files (for integration will build servers 
@@ -34,9 +35,7 @@ import gwen.eval.FeatureResult
   * 
   * @author Branko Juric
   */
-class JUnitReportGenerator(val options: GwenOptions) 
-  extends ReportGenerator(options, None, new File(options.reportDir.get.getPath + "-junit")) 
-  with JUnitReportFormatter {
+class JUnitReportGenerator(val options: GwenOptions) extends ReportGenerator(ReportFormat.junit, options) with JUnitReportFormatter {
 
   override def reportAttachments(spec: FeatureSpec, featureReportFile: File): Unit = {
     // noop

--- a/src/main/scala/gwen/report/junit/JUnitReportGenerator.scala
+++ b/src/main/scala/gwen/report/junit/JUnitReportGenerator.scala
@@ -35,15 +35,22 @@ import gwen.eval.FeatureResult
   * @author Branko Juric
   */
 class JUnitReportGenerator(val options: GwenOptions) 
-  extends ReportGenerator(options, "feature-summary.xml", "xml", Some("junit-xml")) 
+  extends ReportGenerator(options, None, new File(options.reportDir.get.getPath + "-junit")) 
   with JUnitReportFormatter {
 
   override def reportAttachments(spec: FeatureSpec, featureReportFile: File): Unit = {
     // noop
   }
   
-  override def reportMetaDetail(info: GwenInfo, metaSpecs: List[FeatureSpec], featureReportFile: File): List[FeatureResult] = {
+  override def reportMetaDetail(info: GwenInfo, metaSpecs: List[FeatureSpec], featureReportFile: File, dataRecord: Option[DataRecord]): List[FeatureResult] = {
     metaSpecs.map(FeatureResult(_, None, Nil))
+  }
+  
+  override def createReportDir(spec: FeatureSpec, dataRecord: Option[DataRecord]): File = reportDir
+  
+  override def createReportFileName(spec: FeatureSpec, dataRecord: Option[DataRecord]): String = { 
+    val parentDirPath = spec.featureFile.map(_.getParentFile).map(_.getPath).getOrElse("")
+    s"TEST-${FileIO.encodeDir(parentDirPath)}-${encodeDataRecordNo(dataRecord)}${super.createReportFileName(spec, dataRecord)}"
   }
   
 }

--- a/src/main/scala/gwen/report/junit/JUnitReportGenerator.scala
+++ b/src/main/scala/gwen/report/junit/JUnitReportGenerator.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2015 Branko Juric, Brady Wood
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gwen.report.junit
+
+import java.io.File
+import scala.reflect.io.Path
+import gwen.Predefs.FileIO
+import gwen.Predefs.Kestrel
+import gwen.report.ReportGenerator
+import gwen.GwenInfo
+import gwen.eval.GwenOptions
+import gwen.report.html.JUnitReportFormatter
+import gwen.dsl.FeatureSpec
+import gwen.eval.DataRecord
+import gwen.eval.FeatureResult
+
+/**
+  * Generates JUnit xml report files (for integration will build servers 
+  * that support the standand JUnit report syntax).
+  * 
+  * @author Branko Juric
+  */
+class JUnitReportGenerator(val options: GwenOptions) 
+  extends ReportGenerator(options, "feature-summary.xml", "xml", Some("junit-xml")) 
+  with JUnitReportFormatter {
+
+  override def reportAttachments(spec: FeatureSpec, featureReportFile: File): Unit = {
+    // noop
+  }
+  
+  override def reportMetaDetail(info: GwenInfo, metaSpecs: List[FeatureSpec], featureReportFile: File): List[FeatureResult] = {
+    metaSpecs.map(FeatureResult(_, None, Nil))
+  }
+  
+}

--- a/src/test/scala/gwen/eval/GwenLauncherTest.scala
+++ b/src/test/scala/gwen/eval/GwenLauncherTest.scala
@@ -35,6 +35,7 @@ import gwen.dsl.StepKeyword
 import gwen.dsl.Tag
 import gwen.UserOverrides
 import org.scalatest.FlatSpec
+import gwen.report.ReportFormat
 
 class GwenLauncherTest extends FlatSpec with Matchers with MockitoSugar {
   
@@ -218,7 +219,7 @@ class GwenLauncherTest extends FlatSpec with Matchers with MockitoSugar {
     
   }
   
-  "test launcher with reporting" should "generate reports" in {
+  "test launcher with html reporting" should "generate html reports" in {
     
     val dir6 = createDir("dir6");
     val feature6a = createFile("dir6/file6a.feature");
@@ -227,7 +228,7 @@ class GwenLauncherTest extends FlatSpec with Matchers with MockitoSugar {
     val feature7a = createFile("dir7/file7a.feature");
     val reportDir = createDir("report");
     
-    val options = GwenOptions(features = List(dir6, feature7a), parallel = true, reportDir = Some(reportDir))
+    val options = GwenOptions(features = List(dir6, feature7a), parallel = true, reportDir = Some(reportDir), reportFormats = List(ReportFormat.html))
     
     val mockInterpreter = mock[GwenInterpreter[EnvContext]]
     val mockEnv = mock[EnvContext]
@@ -265,10 +266,10 @@ class GwenLauncherTest extends FlatSpec with Matchers with MockitoSugar {
     
     evalStatus should be (Passed(6000))
     
-    new File(reportDir.getPath() + File.separator + "target-GwenLauncherTest-dir6" + File.separator + "file6a", "file6a.feature.html").exists should be (true)
-    new File(reportDir.getPath() + File.separator + "target-GwenLauncherTest-dir6" + File.separator + "file6b", "file6b.feature.html").exists should be (true)
-    new File(reportDir.getPath() + File.separator + "target-GwenLauncherTest-dir7" + File.separator + "file7a", "file7a.feature.html").exists should be (true)
-    new File(reportDir, "feature-summary.html").exists should be (true)
+    new File(reportDir.getPath() + File.separator + "html" + File.separator + "target-GwenLauncherTest-dir6" + File.separator + "file6a", "file6a.feature.html").exists should be (true)
+    new File(reportDir.getPath() + File.separator + "html" + File.separator + "target-GwenLauncherTest-dir6" + File.separator + "file6b", "file6b.feature.html").exists should be (true)
+    new File(reportDir.getPath() + File.separator + "html" + File.separator + "target-GwenLauncherTest-dir7" + File.separator + "file7a", "file7a.feature.html").exists should be (true)
+    new File(reportDir.getPath() + File.separator + "html", "feature-summary.html").exists should be (true)
     new File(reportDir, "index.html").exists should be (true)
     
   }

--- a/src/test/scala/gwen/report/ReportFormatTest.scala
+++ b/src/test/scala/gwen/report/ReportFormatTest.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2015 Branko Juric, Brady Wood
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gwen.report
+
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers
+import gwen.eval.GwenOptions
+import java.io.File
+import gwen.report.html.HtmlReportGenerator
+import gwen.report.junit.JUnitReportGenerator
+
+class ReportFormatTest extends FlatSpec with Matchers  {
+
+  "valueOf of all formats" should "map correctly" in {
+    ReportFormat.withName("html") should be (ReportFormat.html)
+    ReportFormat.withName("junit") should be (ReportFormat.junit)
+  }
+  
+  "File extensions for all report formats" should "map correctly" in {
+    ReportFormat.html.fileExtension should be ("html")
+    ReportFormat.junit.fileExtension should be ("xml")
+  }
+  
+  "Names of all report formats" should "map correctly" in {
+    ReportFormat.html.name should be ("HTML")
+    ReportFormat.junit.name should be ("JUnit-XML")
+  }
+  
+  "Output directory of all report formats" should "map correctly" in {
+    val options = GwenOptions(reportDir = Some(new File("target/report")))
+    ReportFormat.html.reportDir(options).getPath should be (s"target${File.separatorChar}report${File.separatorChar}html")
+    ReportFormat.junit.reportDir(options).getPath should be (s"target${File.separatorChar}report${File.separatorChar}junit")
+  }
+  
+  "Report generator for all report formats" should "map correctly" in {
+    val options = GwenOptions(reportDir = Some(new File("target/report")))
+    ReportFormat.html.reportGenerator(options).isInstanceOf[HtmlReportGenerator] should be (true)
+    ReportFormat.junit.reportGenerator(options).isInstanceOf[JUnitReportGenerator] should be (true)
+  }
+  
+}


### PR DESCRIPTION
This feature supports generating JUnit XML reports in addition to the standard Gwen HTML reports. If `junit` is specified in the `-f/--format` option and `-r/--report <reportDir>` option is also specified, then the junit reports will be written to the `<reportDir>/junit` folder.  HTML reports are now written to the `<reportDir>/html` directory (but index.html in top level will redirect to feature summary as before).

This makes it easy to integrate gwen results with build servers.  To configure the JUnit XML output directory on a build server you can use the following pattern:

`<reportDir>/junit/TEST-*.xml`

For example, if your specified `<reportDir>` is `target/report`:

* The standard HTML Gwen report will be written to `target/report/html`
  * The `target/report/index.html` will redirect to `target/report/html/feature-summary.html`
* The JUnit-XML reports will be written to `target/report/junit`
  * The JUnit output directory pattern for build servers will be `target/report/junit/TEST-*.xml`

If the `-f/--format` option is not specified:
* It will default to `html` (to preserve default behavior) if `-r/--report` is also specified.

If the `-f/--format` option is specified:
* the `-r/--report` option will be mandatory 
* only the report formats specified will be generated (behaves as an override to default `html` format)
   * To generate only JUnit reports, use `-f junit` or `--formats junit`
   * To generate only HTML reports, use `-f html` or `--formats html` (or don't specify the option at all)
   *  To generate both JUnit and HTML reports, use `-f "junit,html"` or `--formats "junit,html"`