### PR TITLE
Feature/slideshow separation

### DIFF
--- a/src/main/scala/gwen/eval/GwenLauncher.scala
+++ b/src/main/scala/gwen/eval/GwenLauncher.scala
@@ -90,7 +90,7 @@ class GwenLauncher[T <: EnvContext](interpreter: GwenInterpreter[T]) extends Laz
         evaluateUnit(options, envOpt, unit) { specs => 
           specs match { 
             case Nil => None
-            case _ => Some(toFeatureResult(reportGenerators, specs, unit.dataRecord))
+            case _ => Some(toFeatureResult(reportGenerators, unit, specs))
           }
         }
       }
@@ -103,7 +103,7 @@ class GwenLauncher[T <: EnvContext](interpreter: GwenInterpreter[T]) extends Laz
           specs match { 
             case Nil => summary
             case specs => 
-              val result = toFeatureResult(reportGenerators, specs, unit.dataRecord)
+              val result = toFeatureResult(reportGenerators, unit, specs)
               summary + result tap { accSummary =>
                 if (!options.parallel) {
                   reportGenerators foreach { _.reportSummary(interpreter, accSummary) }
@@ -136,8 +136,8 @@ class GwenLauncher[T <: EnvContext](interpreter: GwenInterpreter[T]) extends Laz
     }
   }
     
-  private def toFeatureResult(reportGenerators: List[ReportGenerator], specs: List[FeatureSpec], dataRecord: Option[DataRecord]): FeatureResult = {
-    val reportFiles = reportGenerators.flatMap(_.reportDetail(interpreter, specs, dataRecord)).toMap
+  private def toFeatureResult(reportGenerators: List[ReportGenerator], unit: FeatureUnit, specs: List[FeatureSpec]): FeatureResult = {
+    val reportFiles = reportGenerators.flatMap(_.reportDetail(interpreter, unit, specs)).toMap
     FeatureResult(specs.head, if (reportFiles.nonEmpty) Some(reportFiles) else None, specs.tail.map(FeatureResult(_, None, Nil))) tap { result => 
       val status = result.spec.evalStatus
       logger.info("")

--- a/src/main/scala/gwen/report/HtmlReportFormatter.scala
+++ b/src/main/scala/gwen/report/HtmlReportFormatter.scala
@@ -13,11 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package gwen.report.html
+package gwen.report
 
 import java.io.File
 import java.text.DecimalFormat
-import java.util.Date
 import scala.concurrent.duration.Duration
 import gwen.dsl.DurationFormatter
 import gwen.dsl.EvalStatus
@@ -26,15 +25,13 @@ import gwen.dsl.StatusKeyword
 import gwen.dsl.Step
 import gwen.eval.FeatureResult
 import gwen.eval.FeatureSummary
-import gwen.report.ReportFormatter
 import gwen.GwenInfo
 import gwen.eval.GwenOptions
 import gwen.eval.FeatureSummaryLine
 import gwen.dsl.Scenario
 import gwen.dsl.Tag
-import gwen.Settings
 import gwen.GwenSettings
-import gwen.report.ReportFormat
+import gwen.report.ReportFormat.value2ReportFormat
 
 /** Formats the feature summary and detail reports in HTML. */
 trait HtmlReportFormatter extends ReportFormatter {

--- a/src/main/scala/gwen/report/HtmlReportGenerator.scala
+++ b/src/main/scala/gwen/report/HtmlReportGenerator.scala
@@ -39,16 +39,6 @@ class HtmlReportGenerator(val options: GwenOptions) extends ReportGenerator(Repo
   new File(Path(new File(reportDir, "resources/js")).createDirectory().path) tap { dir =>
     copyClasspathTextResourceToFile("/gwen/report/html/js/jquery.min.js", dir)
     copyClasspathTextResourceToFile("/gwen/report/html/js/bootstrap.min.js", dir)
-    copyClasspathTextResourceToFile("/gwen/report/html/js/jquery.reel-min.js", dir)
-  }
-  
-  // copy in font files (if they don't already exist)
-  new File(Path(new File(reportDir, "resources/fonts")).createDirectory().path) tap { dir =>
-    copyClasspathBinaryResourceToFile("/gwen/report/html/fonts/glyphicons-halflings-regular.eot", dir)
-    copyClasspathBinaryResourceToFile("/gwen/report/html/fonts/glyphicons-halflings-regular.svg", dir)
-    copyClasspathBinaryResourceToFile("/gwen/report/html/fonts/glyphicons-halflings-regular.ttf", dir)
-    copyClasspathBinaryResourceToFile("/gwen/report/html/fonts/glyphicons-halflings-regular.woff", dir)
-    copyClasspathBinaryResourceToFile("/gwen/report/html/fonts/glyphicons-halflings-regular.woff2", dir)
   }
   
   // copy in image files (if they don't already exist)

--- a/src/main/scala/gwen/report/HtmlReportGenerator.scala
+++ b/src/main/scala/gwen/report/HtmlReportGenerator.scala
@@ -14,16 +14,12 @@
  * limitations under the License.
  */
 
-package gwen.report.html
+package gwen.report
 
 import java.io.File
 import scala.reflect.io.Path
-import gwen.Predefs.FileIO
 import gwen.Predefs.Kestrel
-import gwen.report.ReportGenerator
-import gwen.GwenInfo
 import gwen.eval.GwenOptions
-import gwen.report.ReportFormat
 
 /**
   * Generates a HTML evaluation report. The report includes a feature

--- a/src/main/scala/gwen/report/HtmlSlideshowFormatter.scala
+++ b/src/main/scala/gwen/report/HtmlSlideshowFormatter.scala
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2014-2015 Branko Juric, Brady Wood
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gwen.report
+
+import java.io.File
+import gwen.GwenInfo
+import gwen.GwenSettings
+import gwen.eval.FeatureResult
+import gwen.eval.FeatureSummary
+import gwen.eval.GwenOptions
+import gwen.report.ReportFormat.value2ReportFormat
+import gwen.eval.FeatureUnit
+
+/** Formats the slideshow. */
+trait HtmlSlideshowFormatter extends ReportFormatter {
+  
+  private val reportFormat = ReportFormat.slideshow
+  
+  /**
+    * Formats the feature detail report as HTML.
+    * 
+    * @param options gwen command line options
+    * @param info the gwen implementation info
+    * @param unit the feature input
+    * @param result the feature result to report
+    * @param breadcrumbs names and references for linking back to parent reports
+    */
+  override def formatDetail(options: GwenOptions, info: GwenInfo, unit: FeatureUnit, result: FeatureResult, breadcrumbs: List[(String, File)]): Option[String] = {
+    val screenshots = result.screenshots
+    if (screenshots.isEmpty || result.isMeta) None
+    else {
+    
+      val reportDir = reportFormat.reportDir(options)
+      val featureName = result.spec.featureFile.map(_.getPath()).getOrElse(result.spec.feature.name)
+      val rootPath = relativePath(result.reports.get(reportFormat), reportDir).filter(_ == File.separatorChar).flatMap(c => "../")
+      val summaryCrumb = ("Summary", new File(s"$rootPath/html", "feature-summary.html"))
+      val featureCrumb = ("Feature", ReportFormat.html.createReportFile(ReportFormat.html.createReportDir(options, result.spec, unit.dataRecord), "", result.spec, unit.dataRecord))
+      Some(s"""<!DOCTYPE html>
+<html lang="en">
+  <head>
+    ${formatHtmlHead(s"Slideshow - ${featureName}", rootPath)}
+    ${formatJsHeader(rootPath)}
+  </head>
+  <body>
+    ${HtmlReportFormatter.formatReportHeader(info, "Feature Slideshow", featureName, rootPath)}
+    ${HtmlReportFormatter.formatStatusHeader(unit, result, rootPath, List(summaryCrumb, featureCrumb), Nil)}
+    ${HtmlSlideshowFormatter.formatSlideshow(screenshots, rootPath, None)}
+  </body>
+</html>""")
+    }
+  }
+  
+  /**
+    * Not used by this implementation.
+    * 
+    * @param options gwen command line options
+    * @param info the gwen implementation info
+    * @param summary the accumulated feature results summary
+    */
+  override def formatSummary(options: GwenOptions, info: GwenInfo, summary: FeatureSummary): Option[String] = None
+  
+  private def formatJsHeader(rootPath: String) = s""" 
+    <script src="${rootPath}resources/js/jquery.min.js"></script>
+    <script src="${rootPath}resources/js/bootstrap.min.js"></script>"""
+    
+  private def formatHtmlHead(title: String, rootPath: String) = s"""
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>${title}</title>
+    <link href="${rootPath}resources/css/bootstrap.min.css" rel="stylesheet" />
+    <link href="${rootPath}resources/css/gwen.css" rel="stylesheet" />"""
+  
+}
+
+object HtmlSlideshowFormatter {
+
+  private def maxFramesPerSec(screenshots: List[File]) = if (screenshots.length < 10) screenshots.length else 10
+  
+  private[report] def formatSlideshow(screenshots: List[File], rootPath: String, size: Option[Int]) = s"""
+<center>
+  <div class="slideshow-body">
+  <p>
+    <div id="loading-div"><span class="glyphicon glyphicon-download" aria-hidden="true"></span> Loading slides, please wait..</div>
+    <div id="controls-div" style="display: none;">
+      <button id="fast-back-btn" class="btn btn-default btn-lg" title="Rewind to start"><span class="glyphicon glyphicon-fast-backward" aria-hidden="true"></span></button>
+      <button id="step-back-btn" class="btn btn-default btn-lg" title="Step backward"><span class="glyphicon glyphicon-step-backward" aria-hidden="true"></span></button>
+      <button id="play-pause-btn" class="btn btn-default btn-lg" title="Play"><span id="play-pause" class="glyphicon glyphicon-play" aria-hidden="true"></span></button>
+      <button id="step-fwd-btn" class="btn btn-default btn-lg" title="Step forward"><span class="glyphicon glyphicon-step-forward" aria-hidden="true"></span></button>
+      <button id="fast-fwd-btn" class="btn btn-default btn-lg" title="Forward to end"><span class="glyphicon glyphicon-fast-forward" aria-hidden="true"></span></button>
+      <select id="current-frame" title="Jump to..">${(for(i <- 1 to screenshots.length) yield s"""
+        <option>${i}</option>""").mkString}        
+      </select> of ${screenshots.length}
+      <span style="margin-left: 30px;"> </span>
+      <button id="decrease-speed-btn" class="btn btn-default btn-lg" title="Decrease Speed"><span class="glyphicon glyphicon-minus" aria-hidden="true"></span></button>
+      <button id="increase-speed-btn" class="btn btn-default btn-lg" title="Increase Speed"><span class="glyphicon glyphicon-plus" aria-hidden="true"></span></button>
+      <select id="frames-per-sec" title="Frames per second..">${(for(i <- 1 to maxFramesPerSec(screenshots) ) yield s"""
+        <option>${i}</option>""").mkString}        
+      </select> frames/sec
+    </div>
+  </p>
+  <hr>
+  <img id="slides" src="${screenshots.headOption.map(_.getName).mkString("attachments/","","")}" ${size.map(s => s"""width="$s%" height="$s%"""").getOrElse("")} />
+  <script src="${rootPath}resources/js/jquery.reel-min.js"></script>
+  <script>
+    var revolution = $$('#slides').width();
+    var unitSpeed = 1 / ${screenshots.length};
+    $$('#slides').reel({
+      images: [ ${screenshots.map(_.getName()).mkString("'attachments/","','attachments/","'")} ],
+      frames: ${screenshots.length},
+      speed: 0,
+      indicator: 5,
+      responsive: ${size.nonEmpty},
+      loops: true,
+      cursor: 'auto',
+      revolution: revolution,
+      steppable: false,
+      preload: 'linear'
+    }).bind("frameChange", function(e, d, frame){
+      if (frame == ${screenshots.length}) { stop(); } 
+      $$('#current-frame').val(frame);
+    }).bind("loaded", function(ev){
+      $$('#loading-div').hide();
+      $$('#controls-div').show();
+    });
+    function play() {
+      $$('#play-pause').removeClass("glyphicon-play");
+      $$('#play-pause').addClass("glyphicon-pause");
+      $$('#play-pause').attr("title", "Pause");
+      if ($$('#slides').reel('frame') == ${screenshots.length}) { $$('#slides').reel('frame', 1); }
+      $$('#slides').trigger("play", getFramesPerSec() * unitSpeed);
+    }
+    function getFramesPerSec() {
+      return parseInt($$('#frames-per-sec').val());
+    }
+    function decreaseSpeed() {
+      var framesPerSec = getFramesPerSec();
+      if (framesPerSec > 1) {
+        framesPerSec = framesPerSec - 1;
+        $$('#frames-per-sec').val(framesPerSec).trigger('change');
+        toggleSpeedButtons(framesPerSec);
+      }
+    }
+    function increaseSpeed() {
+      var framesPerSec = getFramesPerSec();
+      if (framesPerSec < ${maxFramesPerSec(screenshots)}) {
+        framesPerSec = framesPerSec + 1;
+        $$('#frames-per-sec').val(framesPerSec).trigger('change');
+        toggleSpeedButtons(framesPerSec);
+      }
+    }
+    function stop() {
+      $$('#slides').trigger("stop");
+      $$('#play-pause').removeClass("glyphicon-pause");
+      $$('#play-pause').addClass("glyphicon-play");
+      $$('#play-pause').attr("title", "Play");
+    }
+    function toggleSpeedButtons(framesPerSec) {
+      $$('#increase-speed-btn').prop('disabled', framesPerSec == ${maxFramesPerSec(screenshots)});
+      $$('#decrease-speed-btn').prop('disabled', framesPerSec == 1);
+    }
+    $$(function() {
+      $$('#frames-per-sec').val('${GwenSettings.`gwen.report.slideshow.framespersecond`}');
+      $$('#increase-speed-btn').click(function(e) { increaseSpeed() });
+      $$('#decrease-speed-btn').click(function(e) { decreaseSpeed() });
+      toggleSpeedButtons(getFramesPerSec());
+      $$('#fast-back-btn').click(function(e) { $$('#slides').reel('frame', 1); stop(); });
+      $$('#step-back-btn').click(function(e) { $$('#slides').trigger('stepRight'); stop(); });
+      $$('#play-pause-btn').click(function() { 
+        if ($$('#play-pause').hasClass("glyphicon-play")) { play(); } 
+        else if ($$('#play-pause').hasClass("glyphicon-pause")) { stop(); } 
+      });
+      $$('#step-fwd-btn').click(function(e) { $$('#slides').trigger('stepLeft'); stop(); });
+      $$('#fast-fwd-btn').click(function(e) { $$('#slides').reel('frame', ${screenshots.length}); stop(); });
+      $$('#current-frame').change(function(e) { $$('#slides').reel('frame', parseInt($$(this).val())); stop(); });
+      $$('#frames-per-sec').change(function(e) { $$('#slides').reel('speed', parseInt($$(this).val()) * unitSpeed); toggleSpeedButtons(getFramesPerSec()); });
+    });
+  </script>
+</div>
+</center>
+"""
+}

--- a/src/main/scala/gwen/report/HtmlSlideshowGenerator.scala
+++ b/src/main/scala/gwen/report/HtmlSlideshowGenerator.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2014-2015 Branko Juric, Brady Wood
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gwen.report
+
+import java.io.File
+import scala.reflect.io.Path
+import gwen.Predefs.Kestrel
+import gwen.eval.GwenOptions
+
+/**
+  * Generates a slideshow HTML file
+  * 
+  * @author Branko Juric
+  */
+class HtmlSlideshowGenerator(val options: GwenOptions) extends ReportGenerator(ReportFormat.slideshow, options) with HtmlSlideshowFormatter {
+
+  // copy in JS files (if they don't already exist)
+  new File(Path(new File(reportDir, "resources/js")).createDirectory().path) tap { dir =>
+    copyClasspathTextResourceToFile("/gwen/report/html/js/jquery.reel-min.js", dir)
+  }
+  
+  // copy in font files (if they don't already exist)
+  new File(Path(new File(reportDir, "resources/fonts")).createDirectory().path) tap { dir =>
+    copyClasspathBinaryResourceToFile("/gwen/report/html/fonts/glyphicons-halflings-regular.eot", dir)
+    copyClasspathBinaryResourceToFile("/gwen/report/html/fonts/glyphicons-halflings-regular.svg", dir)
+    copyClasspathBinaryResourceToFile("/gwen/report/html/fonts/glyphicons-halflings-regular.ttf", dir)
+    copyClasspathBinaryResourceToFile("/gwen/report/html/fonts/glyphicons-halflings-regular.woff", dir)
+    copyClasspathBinaryResourceToFile("/gwen/report/html/fonts/glyphicons-halflings-regular.woff2", dir)
+  }
+  
+}

--- a/src/main/scala/gwen/report/JUnitReportFormatter.scala
+++ b/src/main/scala/gwen/report/JUnitReportFormatter.scala
@@ -28,6 +28,7 @@ import gwen.dsl.StatusKeyword
 import gwen.eval.FeatureResult
 import gwen.eval.FeatureSummary
 import gwen.eval.GwenOptions
+import gwen.eval.FeatureUnit
 
 /** Formats the feature summary and detail reports in JUnit xml. */
 trait JUnitReportFormatter extends ReportFormatter {
@@ -37,10 +38,11 @@ trait JUnitReportFormatter extends ReportFormatter {
     * 
     * @param options gwen command line options
     * @param info the gwen implementation info
+    * @param unit the feature input
     * @param result the feature result to report
     * @param breadcrumbs names and references for linking back to parent reports
     */
-  override def formatDetail(options: GwenOptions, info: GwenInfo, result: FeatureResult, breadcrumbs: List[(String, File)]): String = {
+  override def formatDetail(options: GwenOptions, info: GwenInfo, unit: FeatureUnit, result: FeatureResult, breadcrumbs: List[(String, File)]): Option[String] = {
     
     val scenarios = result.spec.scenarios.filter(!_.isStepDef)
     val hostname = s""" hostname="${InetAddress.getLocalHost.getHostName}""""
@@ -56,7 +58,7 @@ trait JUnitReportFormatter extends ReportFormatter {
     val time = s""" time="${result.spec.evalStatus.nanos.toDouble / 1000000000d}""""
     val timestamp = s""" timestamp="${new DateTime(result.timestamp).withZone(DateTimeZone.UTC)}""""
     
-    s"""<?xml version="1.0" encoding="UTF-8" ?>
+    Some(s"""<?xml version="1.0" encoding="UTF-8" ?>
 <testsuite${hostname}${name}${pkg}${tests}${errors}${skipped}${time}${timestamp}>
     <properties>${(sys.props.map { case (name, value) => s"""
         <property name="$name" value="$value"/>"""}).mkString}
@@ -73,7 +75,7 @@ trait JUnitReportFormatter extends ReportFormatter {
     case _ => "/>"
   }}"""}).mkString}
 </testsuite>
-"""
+""")
   }
   
   /**

--- a/src/main/scala/gwen/report/JUnitReportFormatter.scala
+++ b/src/main/scala/gwen/report/JUnitReportFormatter.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package gwen.report.html
+package gwen.report
 
 import java.io.File
 import java.net.InetAddress
@@ -28,8 +28,6 @@ import gwen.dsl.StatusKeyword
 import gwen.eval.FeatureResult
 import gwen.eval.FeatureSummary
 import gwen.eval.GwenOptions
-import gwen.report.ReportFormatter
-import gwen.report.ReportFormat
 
 /** Formats the feature summary and detail reports in JUnit xml. */
 trait JUnitReportFormatter extends ReportFormatter {

--- a/src/main/scala/gwen/report/JUnitReportGenerator.scala
+++ b/src/main/scala/gwen/report/JUnitReportGenerator.scala
@@ -17,12 +17,12 @@
 package gwen.report
 
 import java.io.File
-import gwen.Predefs.FileIO
+
 import gwen.GwenInfo
-import gwen.eval.GwenOptions
 import gwen.dsl.FeatureSpec
-import gwen.eval.DataRecord
 import gwen.eval.FeatureResult
+import gwen.eval.FeatureUnit
+import gwen.eval.GwenOptions
 
 /**
   * Generates JUnit xml report files (for integration will build servers 
@@ -36,15 +36,8 @@ class JUnitReportGenerator(val options: GwenOptions) extends ReportGenerator(Rep
     // noop
   }
   
-  override def reportMetaDetail(info: GwenInfo, metaSpecs: List[FeatureSpec], featureReportFile: File, dataRecord: Option[DataRecord]): List[FeatureResult] = {
+  override def reportMetaDetail(info: GwenInfo, unit: FeatureUnit, metaSpecs: List[FeatureSpec], featureReportFile: File): List[FeatureResult] = {
     metaSpecs.map(FeatureResult(_, None, Nil))
-  }
-  
-  override def createReportDir(spec: FeatureSpec, dataRecord: Option[DataRecord]): File = reportDir
-  
-  override def createReportFileName(spec: FeatureSpec, dataRecord: Option[DataRecord]): String = { 
-    val parentDirPath = spec.featureFile.map(_.getParentFile).map(_.getPath).getOrElse("")
-    s"TEST-${FileIO.encodeDir(parentDirPath)}-${encodeDataRecordNo(dataRecord)}${super.createReportFileName(spec, dataRecord)}"
   }
   
 }

--- a/src/main/scala/gwen/report/JUnitReportGenerator.scala
+++ b/src/main/scala/gwen/report/JUnitReportGenerator.scala
@@ -14,20 +14,15 @@
  * limitations under the License.
  */
 
-package gwen.report.junit
+package gwen.report
 
 import java.io.File
-import scala.reflect.io.Path
 import gwen.Predefs.FileIO
-import gwen.Predefs.Kestrel
-import gwen.report.ReportGenerator
 import gwen.GwenInfo
 import gwen.eval.GwenOptions
-import gwen.report.html.JUnitReportFormatter
 import gwen.dsl.FeatureSpec
 import gwen.eval.DataRecord
 import gwen.eval.FeatureResult
-import gwen.report.ReportFormat
 
 /**
   * Generates JUnit xml report files (for integration will build servers 

--- a/src/main/scala/gwen/report/ReportFormat.scala
+++ b/src/main/scala/gwen/report/ReportFormat.scala
@@ -20,6 +20,10 @@ import scala.language.implicitConversions
 import scala.language.postfixOps
 import gwen.eval.GwenOptions
 import java.io.File
+import gwen.dsl.FeatureSpec
+import gwen.eval.DataRecord
+import gwen.Predefs.FileIO
+import scala.reflect.io.Path
 
 /**
   * Enumeration of supported report formats.
@@ -28,17 +32,32 @@ import java.io.File
   */
 object ReportFormat extends Enumeration {
 
-  val html, junit = Value
+  val html, slideshow, junit = Value
   
   class FormatValue(
-      val name: String, 
-      val fileExtension: String, 
-      val summaryFilename: Option[String], 
-      getGenerator: GwenOptions => ReportGenerator, 
-      getReportDir: GwenOptions => File) {
-    def reportGenerator(options: GwenOptions): ReportGenerator = getGenerator(options)
-    def reportDir(options: GwenOptions): File = getReportDir(options)
-  }
+    val name: String, 
+    val fileExtension: String, 
+    val summaryFilename: Option[String], 
+    val getGenerator: GwenOptions => ReportGenerator, 
+    val getReportDir: GwenOptions => File,
+    val getReportDetailFilename: (FeatureSpec, Option[DataRecord]) => String) {
+      def reportGenerator(options: GwenOptions): ReportGenerator = getGenerator(options)
+      def reportDir(options: GwenOptions): File = getReportDir(options)
+      def getReportFilename(spec: FeatureSpec, dataRecord: Option[DataRecord]) = getReportDetailFilename(spec, dataRecord)
+      def createReportDir(options: GwenOptions, spec: FeatureSpec, dataRecord: Option[DataRecord]): File = {
+        val reportDir = getReportDir(options)
+        val dataRecordDir = ReportGenerator.encodeDataRecordNo(dataRecord)
+        val reportPath = spec.featureFile match {
+          case Some(file) =>
+            file.toPath(reportDir, Some(dataRecordDir + FileIO.encodeDir(file.getName().substring(0, file.getName().lastIndexOf(".")))))
+          case None => 
+            reportDir.getPath() + File.separator + dataRecordDir + FileIO.encodeDir(spec.feature.name)
+        }
+        new File(Path(reportPath).createDirectory().path)
+      }
+      def createReportFile(toDir: File, prefix: String, spec: FeatureSpec, dataRecord: Option[DataRecord]): File =
+        new File(toDir, s"${prefix}${getReportFilename(spec, dataRecord)}.${fileExtension}")
+    }
   
   private val Values = Map(
     html -> new FormatValue(
@@ -46,13 +65,30 @@ object ReportFormat extends Enumeration {
         "html", 
         Some("feature-summary"), 
         options => new HtmlReportGenerator(options), 
-        options => options.reportDir.map(new File(_, "html")).get),
+        options => options.reportDir.map(new File(_, "html")).get,
+        (spec: FeatureSpec, dataRecord: Option[DataRecord]) =>
+          spec.featureFile.map(_.getName()).getOrElse(spec.feature.name)),
+    slideshow -> new FormatValue(
+        "Slideshow", 
+        "html", 
+        None, 
+        options => new HtmlSlideshowGenerator(options), 
+        options => options.reportDir.map(new File(_, "html")).get,
+        (spec: FeatureSpec, dataRecord: Option[DataRecord]) =>
+          s"${spec.featureFile.map(_.getName()).getOrElse(spec.feature.name)}.slideshow"),
     junit -> new FormatValue(
         "JUnit-XML", 
         "xml", 
         None, 
         options => new JUnitReportGenerator(options), 
-        options => options.reportDir.map(new File(_, "junit")).get)
+        options => options.reportDir.map(new File(_, "junit")).get,
+        (spec: FeatureSpec, dataRecord: Option[DataRecord]) => {
+          val parentDirPath = spec.featureFile.map(_.getParentFile).map(_.getPath).getOrElse("")
+          val dataRecNo = ReportGenerator.encodeDataRecordNo(dataRecord)
+          s"TEST-${FileIO.encodeDir(parentDirPath)}-${dataRecNo}${spec.featureFile.map(_.getName()).getOrElse(spec.feature.name)}"
+        }) {
+          override def createReportDir(options: GwenOptions, spec: FeatureSpec, dataRecord: Option[DataRecord]): File = getReportDir(options)
+        }
   )
   
   implicit def value2ReportFormat(value: Value) = Values(value)

--- a/src/main/scala/gwen/report/ReportFormat.scala
+++ b/src/main/scala/gwen/report/ReportFormat.scala
@@ -18,9 +18,7 @@ package gwen.report
 
 import scala.language.implicitConversions
 import scala.language.postfixOps
-import gwen.report.html.HtmlReportGenerator
 import gwen.eval.GwenOptions
-import gwen.report.junit.JUnitReportGenerator
 import java.io.File
 
 /**

--- a/src/main/scala/gwen/report/ReportFormatter.scala
+++ b/src/main/scala/gwen/report/ReportFormatter.scala
@@ -20,6 +20,7 @@ import gwen.eval.FeatureResult
 import gwen.eval.FeatureSummary
 import gwen.GwenInfo
 import gwen.eval.GwenOptions
+import gwen.eval.FeatureUnit
 
 /** Trait for formatting the feature summary and detail reports. */
 trait ReportFormatter {
@@ -29,10 +30,11 @@ trait ReportFormatter {
     * 
     * @param options gwen command line options
     * @param info the gwen implementation info
+    * @param unit the feature input
     * @param result the feature result
     * @param breadcrumbs names and references for linking back to parent reports
     */
-  def formatDetail(options: GwenOptions, info: GwenInfo, result: FeatureResult, breadcrumbs: List[(String, File)]): String
+  def formatDetail(options: GwenOptions, info: GwenInfo, unit: FeatureUnit, result: FeatureResult, breadcrumbs: List[(String, File)]): Option[String]
   
   /**
     * Formats the feature summary report.
@@ -42,5 +44,7 @@ trait ReportFormatter {
     * @param summary the accumulated feature results summary
     */
   def formatSummary(options: GwenOptions, info: GwenInfo, summary: FeatureSummary): Option[String]
+  
+  private[report] def relativePath(reportFile: File, reportDir: File) = reportFile.getPath.substring(reportDir.getPath().length() + 1)
   
 }

--- a/src/test/scala/gwen/report/ReportFormatTest.scala
+++ b/src/test/scala/gwen/report/ReportFormatTest.scala
@@ -19,8 +19,6 @@ import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 import gwen.eval.GwenOptions
 import java.io.File
-import gwen.report.html.HtmlReportGenerator
-import gwen.report.junit.JUnitReportGenerator
 
 class ReportFormatTest extends FlatSpec with Matchers  {
 

--- a/src/test/scala/gwen/report/ReportFormatTest.scala
+++ b/src/test/scala/gwen/report/ReportFormatTest.scala
@@ -24,28 +24,33 @@ class ReportFormatTest extends FlatSpec with Matchers  {
 
   "valueOf of all formats" should "map correctly" in {
     ReportFormat.withName("html") should be (ReportFormat.html)
+    ReportFormat.withName("slideshow") should be (ReportFormat.slideshow)
     ReportFormat.withName("junit") should be (ReportFormat.junit)
   }
   
   "File extensions for all report formats" should "map correctly" in {
     ReportFormat.html.fileExtension should be ("html")
+    ReportFormat.slideshow.fileExtension should be ("html")
     ReportFormat.junit.fileExtension should be ("xml")
   }
   
   "Names of all report formats" should "map correctly" in {
     ReportFormat.html.name should be ("HTML")
+    ReportFormat.slideshow.name should be ("Slideshow")
     ReportFormat.junit.name should be ("JUnit-XML")
   }
   
   "Output directory of all report formats" should "map correctly" in {
     val options = GwenOptions(reportDir = Some(new File("target/report")))
     ReportFormat.html.reportDir(options).getPath should be (s"target${File.separatorChar}report${File.separatorChar}html")
+    ReportFormat.slideshow.reportDir(options).getPath should be (s"target${File.separatorChar}report${File.separatorChar}html")
     ReportFormat.junit.reportDir(options).getPath should be (s"target${File.separatorChar}report${File.separatorChar}junit")
   }
   
   "Report generator for all report formats" should "map correctly" in {
     val options = GwenOptions(reportDir = Some(new File("target/report")))
     ReportFormat.html.reportGenerator(options).isInstanceOf[HtmlReportGenerator] should be (true)
+    ReportFormat.slideshow.reportGenerator(options).isInstanceOf[HtmlSlideshowGenerator] should be (true)
     ReportFormat.junit.reportGenerator(options).isInstanceOf[JUnitReportGenerator] should be (true)
   }
   


### PR DESCRIPTION
This feature adds full screen slideshows to existing reports.  The slideshow popup now has a "Full Screen" link in the top left corner that when clicked opens up the slideshow in full screen mode.

<img width="995" alt="slideshow-modal" src="https://cloud.githubusercontent.com/assets/1369994/11323948/3b5c8486-9176-11e5-8f9a-cffd21a93659.png">

Clicking the "Full Screen" link will render the slideshow in its own HTML page (published next to the associated feature report file as `.slideshow.html` on the file system).  In this mode, each image frame is displayed in its original size.

<img width="1058" alt="slideshow-screen" src="https://cloud.githubusercontent.com/assets/1369994/11323950/58262f04-9176-11e5-98e5-6aae803cfb83.png">
