### PR TITLE
Add ramp up interval for staggered parallel execution

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,7 @@
 =====
 Feb 27, 2016, 5:52 PM GMT+11 (AEDT)
 - Add support for configuring a ramp up interval (in seconds) for 
-  stagged parallel exeucution ~ for user request issue #18. The 
+  staggered parallel exeucution ~ for user request issue #18. The 
   interval can be set through the `gwen.rampup.interval.seconds` setting
   (Gwen property). This setting is only applicable for parallel execution 
   mode. If it is not set or is set to zero, then no staggering will occur 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,13 @@
+1.1.0
+=====
+Feb 27, 2016, 5:52 PM GMT+11 (AEDT)
+- Add support for configuring a ramp up interval (in seconds) for 
+  stagged parallel exeucution ~ for user request issue #18. The 
+  interval can be set through the `gwen.rampup.interval.seconds` setting
+  (Gwen property). This setting is only applicable for parallel execution 
+  mode. If it is not set or is set to zero, then no staggering will occur 
+  (as per default behavior).  
+
 1.0.3
 =====
 Feb 11, 2016, 11:33 PM GMT+11 (AEDT)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ interpreter that accepts plain text
 
 [![Build Status](https://travis-ci.org/gwen-interpreter/gwen.svg)](https://travis-ci.org/gwen-interpreter/gwen)
 
-- Current release: [1.0.3](https://github.com/gwen-interpreter/gwen/releases/tag/v1.0.3)
+- Current release: [1.1.0](https://github.com/gwen-interpreter/gwen/releases/tag/v1.1.0)
 - [Change log](CHANGELOG)
 
 ### Automation by Interpretation
@@ -52,6 +52,7 @@ Key Features
 - [REPL console](https://github.com/gwen-interpreter/gwen/wiki/REPL-Console)
 - [Serial execution](https://github.com/gwen-interpreter/gwen/wiki/Execution-Modes#serial-execution)
 - [Parallel execution](https://github.com/gwen-interpreter/gwen/wiki/Execution-Modes#parallel-execution)
+  - with optional ramp up interval
 - [Dry run execution and validation](https://github.com/gwen-interpreter/gwen/wiki/Execution-Modes#dry-run-validation)
 - [Data driven execution](https://github.com/gwen-interpreter/gwen/wiki/Execution-Modes#data-driven-execution)
 - [Meta features](https://github.com/gwen-interpreter/gwen/wiki/Meta-Features)

--- a/src/main/scala/gwen/GwenSettings.scala
+++ b/src/main/scala/gwen/GwenSettings.scala
@@ -52,4 +52,11 @@ object GwenSettings {
     */
   def `gwen.report.overwrite`: Boolean = Settings.getOpt("gwen.report.overwrite").getOrElse("false").toBoolean
   
+  /**
+   * Provides access to the `gwen.rampup.interval.seconds` property setting used
+   * to set the ramp up interval (in seconds) for staggering parallel executions  
+   * (this setting is optional and only used in parallel execution mode).
+   */
+  def `gwen.rampup.interval.seconds`: Option[Int] = Settings.getOpt("gwen.rampup.interval.seconds").map(_.toInt)
+  
 }

--- a/src/main/scala/gwen/eval/GwenLauncher.scala
+++ b/src/main/scala/gwen/eval/GwenLauncher.scala
@@ -87,7 +87,7 @@ class GwenLauncher[T <: EnvContext](interpreter: GwenInterpreter[T]) extends Laz
   private def executeFeatureUnits(options: GwenOptions, featureStream: Stream[FeatureUnit], envOpt: Option[T]): FeatureSummary = {
     val reportGenerators = ReportGenerator.generatorsFor(options)
     if (options.parallel) {
-      val counter = new AtomicInteger(-1)
+      val counter = new AtomicInteger(0)
       val started = new ThreadLocal[Boolean]()
       started.set(false)
       val results = featureStream.par.flatMap { unit =>
@@ -96,7 +96,7 @@ class GwenLauncher[T <: EnvContext](interpreter: GwenInterpreter[T]) extends Laz
           GwenSettings.`gwen.rampup.interval.seconds` foreach { interval =>
             if (interval > 0) {
               val partition = counter.incrementAndGet()
-              val period = partition * interval
+              val period = (partition - 1) * interval
               logger.info(s"Ramp up period for parallel partition $partition is $period second${if(period == 1) "" else "s"}")
               Thread.sleep(period * 1000)
             }

--- a/src/main/scala/gwen/eval/GwenLauncher.scala
+++ b/src/main/scala/gwen/eval/GwenLauncher.scala
@@ -27,6 +27,7 @@ import gwen.report.ReportGenerator
 import scala.concurrent.duration.Duration
 import gwen.GwenSettings
 import gwen.dsl.StatusKeyword
+import java.util.concurrent.atomic.AtomicInteger
 
 /**
   * Launches the gwen interpreter.
@@ -86,7 +87,21 @@ class GwenLauncher[T <: EnvContext](interpreter: GwenInterpreter[T]) extends Laz
   private def executeFeatureUnits(options: GwenOptions, featureStream: Stream[FeatureUnit], envOpt: Option[T]): FeatureSummary = {
     val reportGenerators = ReportGenerator.generatorsFor(options)
     if (options.parallel) {
+      val counter = new AtomicInteger(-1)
+      val started = new ThreadLocal[Boolean]()
+      started.set(false)
       val results = featureStream.par.flatMap { unit =>
+        if (!started.get) {
+          started.set(true)
+          GwenSettings.`gwen.rampup.interval.seconds` foreach { interval =>
+            if (interval > 0) {
+              val partition = counter.incrementAndGet()
+              val period = partition * interval
+              logger.info(s"Ramp up period for parallel partition $partition is $period second${if(period == 1) "" else "s"}")
+              Thread.sleep(period * 1000)
+            }
+          }
+        }
         evaluateUnit(options, envOpt, unit) { result =>
           result.map(bindReportFiles(reportGenerators, unit, _)) tap { _ => result.foreach(logFeatureStatus) }
         }

--- a/version.sbt
+++ b/version.sbt
@@ -1,6 +1,6 @@
 enablePlugins(GitVersioning)
 
-git.baseVersion := "1.0.3"
+git.baseVersion := "1.1.0"
 
 git.useGitDescribe := true
 


### PR DESCRIPTION
This feature is to support user request issue #18

It adds the ability for users to configure a ramp up interval (in seconds) used for staggering parallel executions. The interval can be configured through a new `gwen.rampup.interval.seconds` setting/property.  This setting is only applicable for parallel execution mode. If it is not set or is set to zero, then no staggering will occur (as per the previously default behaviour).

For example, if you set this interval to 5 seconds, the first parallel partition will execute immediately, the second one will execute after 5 seconds, the third one after 10 seconds, and so on. 

`#` gwen.properties or -D command line option
`gwen.rampup.interval.seconds=5`

When you launch Gwen in parallel execution mode with this setting on a quad core machine, the following output will be written to the console log informing you of the allocated ramp up periods (the order in which these are logged is non determinant):

```
INFO - Ramp up period for parallel partition 4 is 15 seconds
INFO - Ramp up period for parallel partition 1 is 0 seconds
INFO - Ramp up period for parallel partition 2 is 5 seconds
INFO - Ramp up period for parallel partition 3 is 10 seconds
```

The staggering will then look like this:
```
|< 0 secs >|<-- feature 1a -->|<-- feature 1b -->|..
|<----- 5 secs >|<-- feature 2a -->|<-- feature 2b -->|..
|<---------- 10 secs >|<-- feature 3a -->|<-- feature 3b -->|..
|<--------------- 15 secs >|<-- feature 4a -->|<-- feature 4b -->|..
```






