### PR TITLE
Optionally suppressing meta reports

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,7 @@
 =====
 Feb 29, 2016, 8:50 PM GMT+11 (AEDT)
 - Added support for configuring a ramp up interval (in seconds) for 
-  staggered parallel exeucution ~ for user request issue #18. The 
+  staggered parallel execution ~ for user request issue #18. The 
   interval can be set through the `gwen.rampup.interval.seconds` setting
   This setting is only applicable for parallel execution mode. If it is 
   not set or is set to zero, then no staggering will occur (as per default 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,12 +1,17 @@
 1.1.0
 =====
-Feb 27, 2016, 5:52 PM GMT+11 (AEDT)
-- Add support for configuring a ramp up interval (in seconds) for 
+Feb 29, 2016, 8:50 PM GMT+11 (AEDT)
+- Added support for configuring a ramp up interval (in seconds) for 
   staggered parallel exeucution ~ for user request issue #18. The 
   interval can be set through the `gwen.rampup.interval.seconds` setting
-  (Gwen property). This setting is only applicable for parallel execution 
-  mode. If it is not set or is set to zero, then no staggering will occur 
-  (as per default behavior).  
+  This setting is only applicable for parallel execution mode. If it is 
+  not set or is set to zero, then no staggering will occur (as per default 
+  behavior). 
+- Added new `gwen.report.suppress.meta` setting for controlling whether or 
+  no meta reports should be generated with HTML reports (default value is 
+  false). If you have a lot of meta, suppressing the meta reports can 
+  save a lot of disk space. Enabling this setting does not suppress the 
+  hyperlinked stepdefs in feature reports (they will always be rendered).
 
 1.0.3
 =====

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,7 +8,7 @@ Feb 29, 2016, 8:50 PM GMT+11 (AEDT)
   not set or is set to zero, then no staggering will occur (as per default 
   behavior). 
 - Added new `gwen.report.suppress.meta` setting for controlling whether or 
-  no meta reports should be generated with HTML reports (default value is 
+  not meta reports should be generated with HTML reports (default value is 
   false). If you have a lot of meta, suppressing the meta reports can 
   save a lot of disk space. Enabling this setting does not suppress the 
   hyperlinked stepdefs in feature reports (they will always be rendered).

--- a/src/main/scala/gwen/GwenSettings.scala
+++ b/src/main/scala/gwen/GwenSettings.scala
@@ -59,4 +59,10 @@ object GwenSettings {
    */
   def `gwen.rampup.interval.seconds`: Option[Int] = Settings.getOpt("gwen.rampup.interval.seconds").map(_.toInt)
   
+  /**
+    * Provides access to the `gwen.report.suppress.meta` setting used to control whether 
+    * or not meta report generation will be suppressed (default value is `false`).
+    */
+  def `gwen.report.suppress.meta`: Boolean = Settings.getOpt("gwen.report.suppress.meta").getOrElse("false").toBoolean
+  
 }

--- a/src/main/scala/gwen/report/HtmlReportFormatter.scala
+++ b/src/main/scala/gwen/report/HtmlReportFormatter.scala
@@ -101,7 +101,7 @@ trait HtmlReportFormatter extends ReportFormatter {
         <ul class="list-group">
           <li class="list-group-item list-group-item-${cssStatus(status)}">
             <div class="container-fluid" style="padding: 0px 0px">
-              ${(metaResults.zipWithIndex map { case (result, rowIndex) => formatSummaryLine(result, s"meta/${reportFiles.tail(rowIndex).getName()}", None, rowIndex)}).mkString}
+              ${(metaResults.zipWithIndex map { case (result, rowIndex) => formatSummaryLine(result, if(GwenSettings.`gwen.report.suppress.meta`) None else Some(s"meta/${reportFiles.tail(rowIndex).getName()}"), None, rowIndex)}).mkString}
             </div>
           </li>
         </ul>
@@ -230,7 +230,7 @@ trait HtmlReportFormatter extends ReportFormatter {
             <div class="container-fluid" style="padding: 0px 0px">${
                 (results.zipWithIndex map { case ((result, resultIndex), rowIndex) => 
                   val reportFile = result.reports.get(ReportFormat.html).head
-                  formatSummaryLine(result, s"${relativePath(reportFile, reportDir).replace(File.separatorChar, '/')}", Some(resultIndex + 1), rowIndex)
+                  formatSummaryLine(result, Some(s"${relativePath(reportFile, reportDir).replace(File.separatorChar, '/')}"), Some(resultIndex + 1), rowIndex)
                 }).mkString}
             </div>
           </li>
@@ -270,14 +270,14 @@ trait HtmlReportFormatter extends ReportFormatter {
             </tr>"""} else ""
   }
   
-  private def formatSummaryLine(result: FeatureResult, reportPath: String, sequenceNo: Option[Int], rowIndex: Int): String = s"""
+  private def formatSummaryLine(result: FeatureResult, reportPath: Option[String], sequenceNo: Option[Int], rowIndex: Int): String = s"""
                 <div class="row${if (rowIndex % 2 == 1) s" bg-altrow-${cssStatus(result.spec.evalStatus.status)}" else "" }">
                   <div class="col-md-3" style="padding-left: 0px">${sequenceNo.map(seq => s"""
                     <div class="line-no"><small>${seq}</small></div>""").getOrElse("")}
                     <span style="padding-left: 15px; white-space: nowrap;"><small>${escapeHtml(result.finished.toString)}</small></span>
                   </div>
-                  <div class="col-md-4">
-                    <a class="text-${cssStatus(result.spec.evalStatus.status)}" href="${reportPath}">${escapeHtml(result.spec.feature.name)}</a>
+                  <div class="col-md-4">${reportPath.fold(s"${escapeHtml(result.spec.feature.name)}") { rpath =>
+                    s"""<a class="text-${cssStatus(result.spec.evalStatus.status)}" href="${rpath}">${escapeHtml(result.spec.feature.name)}</a>"""}}
                   </div>
                   <div class="col-md-5">
                     <span class="pull-right"><small>${formatDuration(result.duration)}</small></span> ${result.spec.featureFile.map(_.getPath()).getOrElse("")}

--- a/src/main/scala/gwen/report/ReportGenerator.scala
+++ b/src/main/scala/gwen/report/ReportGenerator.scala
@@ -75,14 +75,18 @@ class ReportGenerator (
   }
   
   private[report] def reportMetaDetail(info: GwenInfo, unit: FeatureUnit, metaResults: List[FeatureResult], reportFiles: List[File]): List[File] = {
-    metaResults.zipWithIndex flatMap { case (metaResult, idx) =>
-      val featureCrumb = ("Feature", reportFiles.head)
-      val breadcrumbs = summaryReportFile.map(f => List(("Summary", f), featureCrumb)).getOrElse(List(featureCrumb))
-      val reportFile = reportFiles.tail(idx)
-      formatDetail(options, info, unit, metaResult, breadcrumbs, reportFile :: Nil) map { content => 
-        reportFile tap { file =>
-          file.writeText(content) 
-          logger.info(s"${reportFormat.name} meta detail report generated: ${file.getAbsolutePath()}")
+    if (GwenSettings.`gwen.report.suppress.meta`) {
+      Nil
+    } else {
+      metaResults.zipWithIndex flatMap { case (metaResult, idx) =>
+        val featureCrumb = ("Feature", reportFiles.head)
+        val breadcrumbs = summaryReportFile.map(f => List(("Summary", f), featureCrumb)).getOrElse(List(featureCrumb))
+        val reportFile = reportFiles.tail(idx)
+        formatDetail(options, info, unit, metaResult, breadcrumbs, reportFile :: Nil) map { content => 
+          reportFile tap { file =>
+            file.writeText(content) 
+            logger.info(s"${reportFormat.name} meta detail report generated: ${file.getAbsolutePath()}")
+          }
         }
       }
     }


### PR DESCRIPTION
This feature introduces the following new setting which users can enable suppress meta reports when the HTML reports are generated:

`gwen.report.suppress.meta=true|false`

This setting is disabled (`false`) by default.

If you have a lot of meta, suppressing the meta reports can save a lot of disk space. Enabling this setting will not suppress the hyperlinked stepdefs in feature reports (they will always be rendered). Also, meta timings will still be rendered and factored into the reports, but there will be no hyperlink to the meta report itself.