### PR TITLE
Meta imports

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,8 @@ Aug 25, 2016, 12:55 AM GMT+10 (AEST)
 - Make failed status in detail report a hyperlink to first failed scenario
 - Add support for importing meta through feature level @Import("pathTo/file.meta") annotation
   - the path to the meta file is relative to the working directory where gwen is invoked 
+- Internally store tags in list instead of set
+- Display elapsed time on report summary lines
 
 1.3.4
 =====

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,11 @@
-1.3.5
+1.4.0
 =====
-Aug 19, 2016, 11:48 PM GMT+10 (AEST)
+Aug 25, 2016, 12:55 AM GMT+10 (AEST)
 - Include total elapsed time at the top of all reports
 - Include start and finish times at the top of all reports
-- Make failed status in detail report a hyperlink to first failed scenario  
+- Make failed status in detail report a hyperlink to first failed scenario
+- Add support for importing meta through feature level @Import("pathTo/file.meta") annotation
+  - the path to the meta file is relative to the working directory where gwen is invoked 
 
 1.3.4
 =====

--- a/src/main/scala/gwen/dsl/PrettyPrinter.scala
+++ b/src/main/scala/gwen/dsl/PrettyPrinter.scala
@@ -63,7 +63,7 @@ object prettyPrint {
     * 
     * @param tags the tags to format
     */
-  private def formatTags(indent: String, tags: Set[Tag]):String = tags.toList match {
+  private def formatTags(indent: String, tags: List[Tag]):String = tags.toList match {
     case _ :: _ =>  s"${indent}${tags.mkString(" ")}\n"
     case _ => ""
   }

--- a/src/main/scala/gwen/dsl/SpecAST.scala
+++ b/src/main/scala/gwen/dsl/SpecAST.scala
@@ -104,22 +104,22 @@ object FeatureSpec {
 /**
   * Captures a gherkin feature node.
   *
-  * @param tags set of tags
+  * @param tags list of tags
   * @param name the feature name
   * @param description optional description
   *
   * @author Branko Juric
   */
-case class Feature(tags: Set[Tag], name: String, description: List[String]) extends SpecNode {
+case class Feature(tags: List[Tag], name: String, description: List[String]) extends SpecNode {
   override def toString = name
 }
 object Feature {
   def apply(spec: gherkin.ast.Feature): Feature =
     Feature(
-      Option(spec.getTags).map(_.toList).getOrElse(Nil).map(t =>Tag(t)).toSet, 
+      Option(spec.getTags).map(_.toList).getOrElse(Nil).map(t =>Tag(t)), 
       spec.getName, 
-      Option(spec.getDescription).map(_.split("\n").toList.map(_.trim)).getOrElse(Nil))
-  def apply(name: String, description: List[String]): Feature = new Feature(Set(), name, description)
+      Option(spec.getDescription).map(_.split("\n").toList.map(_.trim)).getOrElse(Nil).distinct)
+  def apply(name: String, description: List[String]): Feature = new Feature(Nil, name, description)
 }
 
 /**
@@ -152,7 +152,7 @@ object Background {
 
 /**
   * Captures a gherkin scenario.
-  * @param tags set of tags
+  * @param tags list of tags
   * @param name the scenario name
   * @param description the optional background description
   * @param background optional background
@@ -161,7 +161,7 @@ object Background {
   *
   * @author Branko Juric
   */
-case class Scenario(tags: Set[Tag], name: String, description: List[String], background: Option[Background], steps: List[Step], metaFile: Option[File]) extends SpecNode {
+case class Scenario(tags: List[Tag], name: String, description: List[String], background: Option[Background], steps: List[Step], metaFile: Option[File]) extends SpecNode {
   
   /**
     * Returns a list containing all the background steps (if any) followed by 
@@ -181,14 +181,14 @@ case class Scenario(tags: Set[Tag], name: String, description: List[String], bac
 object Scenario {
   def apply(scenario: gherkin.ast.ScenarioDefinition): Scenario = 
     new Scenario(
-      Option(scenario.getTags).map(_.toList).getOrElse(Nil).map(t => Tag(t)).toSet, 
+      Option(scenario.getTags).map(_.toList).getOrElse(Nil).map(t => Tag(t)).distinct, 
       scenario.getName, 
       Option(scenario.getDescription).map(_.split("\n").toList.map(_.trim)).getOrElse(Nil),
       None, 
       Option(scenario.getSteps).map(_.toList).getOrElse(Nil).map(s => Step(s)), 
       None)
-  def apply(tags: Set[Tag], name: String, description: List[String], background: Option[Background], steps: List[Step]): Scenario = 
-    new Scenario(tags, name, description, background, steps, None)
+  def apply(tags: List[Tag], name: String, description: List[String], background: Option[Background], steps: List[Step]): Scenario = 
+    new Scenario(tags.distinct, name, description, background, steps, None)
   def apply(scenario: Scenario, background: Option[Background], steps: List[Step]): Scenario = 
     apply(scenario.tags, scenario.name, scenario.description, background, steps, scenario.metaFile)
   def apply(scenario: Scenario, metaFile: Option[File]): Scenario = 

--- a/src/main/scala/gwen/dsl/SpecNormaliser.scala
+++ b/src/main/scala/gwen/dsl/SpecNormaliser.scala
@@ -63,7 +63,7 @@ trait SpecNormaliser {
       val keyword = if (index == 0) StepKeyword.Given else StepKeyword.And 
       Step(Position(0, 0), keyword, s"""$name is "$value"""")
     }
-    val tags = Set(Tag(s"""Data(file="${dataRecord.dataFilePath}", record=${dataRecord.recordNo})"""))
+    val tags = List(Tag(s"""Data(file="${dataRecord.dataFilePath}", record=${dataRecord.recordNo})"""))
     Scenario(tags, s"Bind data attributes", Nil, None, steps.toList, None) :: featureScenarios(spec, scenarios)
   }
     

--- a/src/main/scala/gwen/errors.scala
+++ b/src/main/scala/gwen/errors.scala
@@ -25,6 +25,7 @@ package gwen {
   package object errors {
 
     import gwen.dsl.Step
+    import gwen.dsl.Tag
 
     def parsingError(msg: String) = throw new ParsingException(msg)
     def ambiguousCaseError(msg: String) = throw new AmbiguousCaseException(msg)
@@ -44,8 +45,9 @@ package gwen {
     def recursiveStepDefError(stepDef: Scenario, step: Step) = throw new RecursiveStepDefException(stepDef, step)
     def decodingError(msg: String) = throw new DecodingException(msg)
     def invalidStepDefError(stepDef: Scenario, msg: String) = throw new InvalidStepDefException(stepDef, msg)
-    def missingImportError(file: File) = throw new MissingImportException(file)
-    def unsupportedImportError(file: File) = throw new UnsupportedImportException(file)
+    def missingImportError(importTag: Tag, specFile: File) = throw new MissingImportException(importTag, specFile)
+    def unsupportedImportError(importTag: Tag, specFile: File) = throw new UnsupportedImportException(importTag, specFile)
+    def recursiveImportError(importTag: Tag, specFile: File) = throw new RecursiveImportException(importTag, specFile)
 
     /** Thrown when a parsing error occurs. */
     class ParsingException(msg: String) extends Exception(msg)
@@ -99,10 +101,15 @@ package gwen {
     class InvalidStepDefException(stepDef: Scenario, msg: String) extends Exception(s"Invalid StepDef: ${stepDef}: $msg")
     
     /** Thrown when an import file is not found. */
-    class MissingImportException(file: File) extends Exception(s"Import file not found: ${file}")
+    class MissingImportException(importTag: Tag, specFile: File) extends Exception(s"Missing file detected in ${importTag} declared in ${specFile}")
     
     /** Thrown when an unsupported import file is detected. */
-    class UnsupportedImportException(file: File) extends Exception(s"Unsupported import file (only files with .meta extension allowed): ${file}")
+    class UnsupportedImportException(importTag: Tag, specFile: File) extends Exception(s"Unsupported file type detected in ${importTag} declared in ${specFile} (only .meta files can be imported)")
+    
+    /** Thrown when a recursive import is detected. */
+    class RecursiveImportException(importTag: Tag, specFile: File) extends Exception(s"Recursive (cyclic) ${importTag} declared in ${specFile}") {
+      override def fillInStackTrace() = this
+    }
 
   }
 }

--- a/src/main/scala/gwen/errors.scala
+++ b/src/main/scala/gwen/errors.scala
@@ -44,6 +44,8 @@ package gwen {
     def recursiveStepDefError(stepDef: Scenario, step: Step) = throw new RecursiveStepDefException(stepDef, step)
     def decodingError(msg: String) = throw new DecodingException(msg)
     def invalidStepDefError(stepDef: Scenario, msg: String) = throw new InvalidStepDefException(stepDef, msg)
+    def missingImportError(file: File) = throw new MissingImportException(file)
+    def unsupportedImportError(file: File) = throw new UnsupportedImportException(file)
 
     /** Thrown when a parsing error occurs. */
     class ParsingException(msg: String) extends Exception(msg)
@@ -95,6 +97,12 @@ package gwen {
     
     /** Thrown when an invalid StepDef is detected. */
     class InvalidStepDefException(stepDef: Scenario, msg: String) extends Exception(s"Invalid StepDef: ${stepDef}: $msg")
+    
+    /** Thrown when an import file is not found. */
+    class MissingImportException(file: File) extends Exception(s"Import file not found: ${file}")
+    
+    /** Thrown when an unsupported import file is detected. */
+    class UnsupportedImportException(file: File) extends Exception(s"Unsupported import file (only files with .meta extension allowed): ${file}")
 
   }
 }

--- a/src/main/scala/gwen/errors.scala
+++ b/src/main/scala/gwen/errors.scala
@@ -48,6 +48,7 @@ package gwen {
     def missingImportError(importTag: Tag, specFile: File) = throw new MissingImportException(importTag, specFile)
     def unsupportedImportError(importTag: Tag, specFile: File) = throw new UnsupportedImportException(importTag, specFile)
     def recursiveImportError(importTag: Tag, specFile: File) = throw new RecursiveImportException(importTag, specFile)
+    def syntaxError(msg: String) = throw new SyntaxException(msg)
 
     /** Thrown when a parsing error occurs. */
     class ParsingException(msg: String) extends Exception(msg)
@@ -107,9 +108,12 @@ package gwen {
     class UnsupportedImportException(importTag: Tag, specFile: File) extends Exception(s"Unsupported file type detected in ${importTag} declared in ${specFile} (only .meta files can be imported)")
     
     /** Thrown when a recursive import is detected. */
-    class RecursiveImportException(importTag: Tag, specFile: File) extends Exception(s"Recursive (cyclic) ${importTag} declared in ${specFile}") {
+    class RecursiveImportException(importTag: Tag, specFile: File) extends Exception(s"Recursive (cyclic) ${importTag} detected in ${specFile}") {
       override def fillInStackTrace() = this
     }
+    
+    /** Thrown when a syntax error is detected. */
+    class SyntaxException(msg: String) extends Exception(msg)
 
   }
 }

--- a/src/main/scala/gwen/eval/EnvContext.scala
+++ b/src/main/scala/gwen/eval/EnvContext.scala
@@ -60,6 +60,9 @@ class EnvContext(options: GwenOptions, scopes: ScopedDataStack) extends LazyLogg
   /** The current type of specification being interpreted. */
   var specType = SpecType.feature
   
+  /** Currently list of loaded meta (used to track and avoid duplicate meta loads). */
+  var loadedMeta: List[File] = Nil  
+  
   /** Provides access to the global feature scope. */
   def featureScope = scopes.featureScope
   
@@ -78,6 +81,7 @@ class EnvContext(options: GwenOptions, scopes: ScopedDataStack) extends LazyLogg
     stepDefs = Map[String, Scenario]()
     resetAttachments
     attachmentPrefix = padWithZeroes(1)
+    loadedMeta = Nil
   }
     
   def json: JsObject = scopes.json

--- a/src/main/scala/gwen/eval/EnvContext.scala
+++ b/src/main/scala/gwen/eval/EnvContext.scala
@@ -113,7 +113,7 @@ class EnvContext(options: GwenOptions, scopes: ScopedDataStack) extends LazyLogg
     StepKeyword.literals foreach { keyword => 
       if (stepDef.name.startsWith(keyword)) invalidStepDefError(stepDef, s"name cannot start with $keyword keyword")
     }
-    val tags = stepDef.metaFile.map(meta => stepDef.tags + Tag(s"""Meta("${meta.getPath()}")""")).getOrElse(stepDef.tags)
+    val tags = stepDef.metaFile.map(meta => Tag(s"""Meta("${meta.getPath()}")""")::stepDef.tags).getOrElse(stepDef.tags)
     stepDefs += ((stepDef.name, Scenario(tags, stepDef.name, stepDef.description, stepDef.background, stepDef.steps, stepDef.metaFile))) 
   }
   

--- a/src/main/scala/gwen/eval/FeatureResult.scala
+++ b/src/main/scala/gwen/eval/FeatureResult.scala
@@ -45,7 +45,7 @@ class FeatureResult(
   def summary = FeatureSummary(this)
   private[eval] def scenarioCounts = StatusKeyword.countsByStatus(spec.scenarios.map(_.evalStatus))
   private[eval] def stepCounts = StatusKeyword.countsByStatus(spec.scenarios.flatMap(_.allSteps.map(_.evalStatus)))
-  override def toString = s"[${formatDuration(spec.evalStatus.duration)}] ${spec.evalStatus.status} ${finished} [${formatDuration(elapsedTime)}] Elapsed (Overhead: ${formatDuration(elapsedTime - spec.evalStatus.duration)}) ${spec.evalStatus.emoticon}"
+  override def toString = s"[${formatDuration(spec.evalStatus.duration)}] ${spec.evalStatus.status} [${formatDuration(elapsedTime)}] Elapsed [${formatDuration(elapsedTime - spec.evalStatus.duration)}] Overhead ${finished} ${spec.evalStatus.emoticon}"
   
 }
 

--- a/src/main/scala/gwen/eval/FeatureSummary.scala
+++ b/src/main/scala/gwen/eval/FeatureSummary.scala
@@ -75,7 +75,7 @@ case class FeatureSummary(
         |${scenarioCount} scenario${if (scenarioCount == 1) "" else "s"}: ${formatCounts(scenarioCounts)}
         |${stepCount} step${if (stepCount == 1) "" else "s"}: ${formatCounts(stepCounts)}
         |
-        |[${formatDuration(evalStatus.duration)}] ${evalStatus.status} ${finished} [${formatDuration(elapsedTime)}] Elapsed (Overhead: ${formatDuration(elapsedTime - evalStatus.duration)}) ${evalStatus.emoticon}""".stripMargin
+        |[${formatDuration(evalStatus.duration)}] ${evalStatus.status} [${formatDuration(elapsedTime)}] Elapsed [${formatDuration(elapsedTime - evalStatus.duration)}] Overhead ${finished} ${evalStatus.emoticon}""".stripMargin
   }
   
   private def formatCounts(counts: Map[StatusKeyword.Value, Int]) = 

--- a/src/main/scala/gwen/eval/GwenInterpreter.scala
+++ b/src/main/scala/gwen/eval/GwenInterpreter.scala
@@ -269,7 +269,7 @@ class GwenInterpreter[T <: EnvContext] extends GwenInfo with GherkinParser with 
           recursiveImportError(tag, specFile)
         }
         Some(file)
-      case r"""Import.*""" =>
+      case r"""(?:I|i)mport\(.*""" =>
         syntaxError(s"""Invalid import syntax: $tag - correct syntax is @Import("filepath")""")
       case _ => None
     }

--- a/src/main/scala/gwen/report/HtmlReportFormatter.scala
+++ b/src/main/scala/gwen/report/HtmlReportFormatter.scala
@@ -228,7 +228,7 @@ trait HtmlReportFormatter extends ReportFormatter {
           val total = summary.results.size
           val countOfTotal = s"""${count} ${if (count != total) s" of ${total} features" else s"feature${if (total > 1) "s" else ""}"}"""
           s"""${countOfTotal}${if (count > 1) s"""
-          <span class="pull-right"><small>${formatDuration(results.map(_._1.spec.evalStatus.duration).reduceLeft(_+_))}</small></span>""" else ""}"""}
+          <span class="pull-right"><small>${formatDuration(results.map(_._1.elapsedTime).reduceLeft(_+_))}</small></span>""" else ""}"""}
         </li>
       </ul>
       <div class="panel-body">
@@ -287,7 +287,7 @@ trait HtmlReportFormatter extends ReportFormatter {
                     s"""<a class="text-${cssStatus(result.spec.evalStatus.status)}" href="${rpath}">${escapeHtml(result.spec.feature.name)}</a>"""}}
                   </div>
                   <div class="col-md-5">
-                    <span class="pull-right"><small>${formatDuration(result.spec.evalStatus.duration)}</small></span> ${result.spec.featureFile.map(_.getPath()).getOrElse("")}
+                    <span class="pull-right"><small>${formatDuration(result.elapsedTime)}</small></span> ${result.spec.featureFile.map(_.getPath()).getOrElse("")}
                   </div>
                 </div>"""
 

--- a/src/test/scala/gwen/dsl/GherkinParserTest.scala
+++ b/src/test/scala/gwen/dsl/GherkinParserTest.scala
@@ -78,14 +78,14 @@ class GherkinParserTest extends FlatSpec with Matchers with GherkinParser {
         }
         featureSpec.scenarios should be {
           List(
-            Scenario(Set[Tag](), "Evaluation", Nil, None,
+            Scenario(List[Tag](), "Evaluation", Nil, None,
               List(
                 Step(Position(17, 9), StepKeyword.Given, "any software behavior"),
                 Step(Position(18, 10), StepKeyword.When,  "expressed in Gherkin"),
                 Step(Position(19, 10), StepKeyword.Then,  "Gwen can evaluate it")
               )
             ),
-            Scenario(Set[Tag](), "The useless test", Nil, None, 
+            Scenario(List[Tag](), "The useless test", Nil, None, 
               List(
                 Step(Position(22, 9), StepKeyword.Given, "I am a test"),
                 Step(Position(23, 11), StepKeyword.And,   "I am generated from code"),
@@ -95,7 +95,7 @@ class GherkinParserTest extends FlatSpec with Matchers with GherkinParser {
                 Step(Position(27, 11), StepKeyword.And,   "that's why I'm useless")
               )
             ),
-            Scenario(Set[Tag](), "The useful test", Nil, None, 
+            Scenario(List[Tag](), "The useful test", Nil, None, 
               List(
                 Step(Position(30, 9), StepKeyword.Given, "I am a test"),
                 Step(Position(31, 11), StepKeyword.And,   "I am written by a human"),

--- a/src/test/scala/gwen/dsl/PrettyPrintParserTest.scala
+++ b/src/test/scala/gwen/dsl/PrettyPrintParserTest.scala
@@ -60,7 +60,7 @@ class PrettyPrintParserTest extends FlatSpec with Matchers with SpecNormaliser w
     
     ast2 match {
       case Success(featureSpec) => 
-        featureSpec.feature should be (Feature(Set(Tag("wip")), "Gwen", List("As a tester", "I want to automate tests", "So that gwen can run them")))
+        featureSpec.feature should be (Feature(List(Tag("wip")), "Gwen", List("As a tester", "I want to automate tests", "So that gwen can run them")))
         featureSpec.background.get should be {
           Background("The butterfly effect", List("Sensitivity to initial conditions"),
             List(
@@ -72,14 +72,14 @@ class PrettyPrintParserTest extends FlatSpec with Matchers with SpecNormaliser w
         }
         featureSpec.scenarios should be {
           List(
-            Scenario(Set(Tag("wip"), Tag("test")), "Evaluation", List("Gwen for executable specifications", "Business specs mapped to meta"), None,
+            Scenario(List(Tag("wip"), Tag("test")), "Evaluation", List("Gwen for executable specifications", "Business specs mapped to meta"), None,
               List(
                 Step(Position(17, 7), StepKeyword.Given, "any software behavior"),
                 Step(Position(18, 8), StepKeyword.When,  "expressed in Gherkin"),
                 Step(Position(19, 8), StepKeyword.Then,  "Gwen can evaluate it")
               )
             ),
-            Scenario(Set[Tag](), "Evaluation", Nil, None, 
+            Scenario(List[Tag](), "Evaluation", Nil, None, 
               List(
                 Step(Position(22, 7), StepKeyword.Given, "any software behavior"),
                 Step(Position(23, 8), StepKeyword.When,  "expressed in Gherkin"),

--- a/src/test/scala/gwen/dsl/ScenarioParserTest.scala
+++ b/src/test/scala/gwen/dsl/ScenarioParserTest.scala
@@ -35,35 +35,35 @@ class ScenarioParserTest extends FlatSpec with Matchers with GherkinParser {
   
   "Valid scenarios" should "parse" in {
       
-      parse("Scenario:").get   should be (Scenario(Set[Tag](), "", Nil, None, Nil))
-      parse("Scenario:\n").get should be (Scenario(Set[Tag](), "", Nil, None, Nil))
+      parse("Scenario:").get   should be (Scenario(List[Tag](), "", Nil, None, Nil))
+      parse("Scenario:\n").get should be (Scenario(List[Tag](), "", Nil, None, Nil))
       
-      parse(s"Scenario:name\n$step1").get   should be (Scenario(Set[Tag](), "name", Nil, None, List(Step(step1, Position(3, 1)))))
-      parse(s"Scenario: name\n$step1").get  should be (Scenario(Set[Tag](), "name", Nil, None, List(Step(step1, Position(3, 1)))))
+      parse(s"Scenario:name\n$step1").get   should be (Scenario(List[Tag](), "name", Nil, None, List(Step(step1, Position(3, 1)))))
+      parse(s"Scenario: name\n$step1").get  should be (Scenario(List[Tag](), "name", Nil, None, List(Step(step1, Position(3, 1)))))
       
-      parse(s"Scenario:name\nI am a test scenario\n$step1").get   should be (Scenario(Set[Tag](), "name", List("I am a test scenario"), None, List(Step(step1, Position(4, 1)))))
-      parse(s"Scenario: name\nI am another\nmultiline\n\nscenario\n$step1").get  should be (Scenario(Set[Tag](), "name", List("I am another", "multiline", "", "scenario"), None, List(Step(step1, Position(7, 1)))))
+      parse(s"Scenario:name\nI am a test scenario\n$step1").get   should be (Scenario(List[Tag](), "name", List("I am a test scenario"), None, List(Step(step1, Position(4, 1)))))
+      parse(s"Scenario: name\nI am another\nmultiline\n\nscenario\n$step1").get  should be (Scenario(List[Tag](), "name", List("I am another", "multiline", "", "scenario"), None, List(Step(step1, Position(7, 1)))))
       
-      parse(s"\tScenario:name\n$step1").get     should be (Scenario(Set[Tag](), "name", Nil, None, List(Step(step1, Position(3, 1)))))
-      parse(s"Scenario:\tname\n$step1").get     should be (Scenario(Set[Tag](), "name", Nil, None, List(Step(step1, Position(3, 1)))))
-      parse(s"Scenario:\tname\t\n$step1").get   should be (Scenario(Set[Tag](), "name", Nil, None, List(Step(step1, Position(3, 1)))))
-      parse(s"Scenario:\tname \n$step1").get    should be (Scenario(Set[Tag](), "name", Nil, None, List(Step(step1, Position(3, 1)))))
-      parse(s"Scenario:\tname\t \n$step1").get  should be (Scenario(Set[Tag](), "name", Nil, None, List(Step(step1, Position(3, 1)))))
+      parse(s"\tScenario:name\n$step1").get     should be (Scenario(List[Tag](), "name", Nil, None, List(Step(step1, Position(3, 1)))))
+      parse(s"Scenario:\tname\n$step1").get     should be (Scenario(List[Tag](), "name", Nil, None, List(Step(step1, Position(3, 1)))))
+      parse(s"Scenario:\tname\t\n$step1").get   should be (Scenario(List[Tag](), "name", Nil, None, List(Step(step1, Position(3, 1)))))
+      parse(s"Scenario:\tname \n$step1").get    should be (Scenario(List[Tag](), "name", Nil, None, List(Step(step1, Position(3, 1)))))
+      parse(s"Scenario:\tname\t \n$step1").get  should be (Scenario(List[Tag](), "name", Nil, None, List(Step(step1, Position(3, 1)))))
       
-      parse(s"Scenario: name\n$step1\n$step2").get should be (Scenario(Set[Tag](), "name", Nil, None, List(Step(step1, Position(3, 1)), Step(step2, Position(4, 1)))))
+      parse(s"Scenario: name\n$step1\n$step2").get should be (Scenario(List[Tag](), "name", Nil, None, List(Step(step1, Position(3, 1)), Step(step2, Position(4, 1)))))
       
-      parse(s"Scenario: name\n$step1\n$comment1").get            should be (Scenario(Set[Tag](), "name", Nil, None, List(Step(step1, Position(3, 1)))))
-      parse(s"Scenario: name\n$step1\n$step2\n$comment1").get    should be (Scenario(Set[Tag](), "name", Nil, None, List(Step(step1, Position(3, 1)), Step(step2, Position(4, 1)))))
-      parse(s"Scenario: name\n$step1\n$comment1\n$step2").get    should be (Scenario(Set[Tag](), "name", Nil, None, List(Step(step1, Position(3, 1)), Step(step2, Position(5, 1)))))
-      parse(s"Scenario: name\n$comment1\n$step1\n$step2").get    should be (Scenario(Set[Tag](), "name", Nil, None, List(Step(step1, Position(4, 1)), Step(step2, Position(5, 1)))))
+      parse(s"Scenario: name\n$step1\n$comment1").get            should be (Scenario(List[Tag](), "name", Nil, None, List(Step(step1, Position(3, 1)))))
+      parse(s"Scenario: name\n$step1\n$step2\n$comment1").get    should be (Scenario(List[Tag](), "name", Nil, None, List(Step(step1, Position(3, 1)), Step(step2, Position(4, 1)))))
+      parse(s"Scenario: name\n$step1\n$comment1\n$step2").get    should be (Scenario(List[Tag](), "name", Nil, None, List(Step(step1, Position(3, 1)), Step(step2, Position(5, 1)))))
+      parse(s"Scenario: name\n$comment1\n$step1\n$step2").get    should be (Scenario(List[Tag](), "name", Nil, None, List(Step(step1, Position(4, 1)), Step(step2, Position(5, 1)))))
       
-      parse(s"Scenario:\n$step1\n$step2").get    should be (Scenario(Set[Tag](), s"", Nil, None, List(Step(step1, Position(3, 1)), Step(step2, Position(4, 1)))))
-      parse(s"Scenario: \n$step1\n$step2").get   should be (Scenario(Set[Tag](), s"", Nil, None, List(Step(step1, Position(3, 1)), Step(step2, Position(4, 1)))))
+      parse(s"Scenario:\n$step1\n$step2").get    should be (Scenario(List[Tag](), s"", Nil, None, List(Step(step1, Position(3, 1)), Step(step2, Position(4, 1)))))
+      parse(s"Scenario: \n$step1\n$step2").get   should be (Scenario(List[Tag](), s"", Nil, None, List(Step(step1, Position(3, 1)), Step(step2, Position(4, 1)))))
       
-      parse("Scenario: I dont have any steps").get should be (Scenario(Set[Tag](), "I dont have any steps", Nil, None, Nil))
+      parse("Scenario: I dont have any steps").get should be (Scenario(List[Tag](), "I dont have any steps", Nil, None, Nil))
       
       StepKeyword.values foreach { keyword =>
-        parse(s"Scenario: I contain a $keyword keyword in name\n$step1").get should be (Scenario(Set[Tag](), s"I contain a $keyword keyword in name", Nil, None, List(Step(step1, Position(3, 1)))))
+        parse(s"Scenario: I contain a $keyword keyword in name\n$step1").get should be (Scenario(List[Tag](), s"I contain a $keyword keyword in name", Nil, None, List(Step(step1, Position(3, 1)))))
       }
   }
   

--- a/src/test/scala/gwen/dsl/SpecNormaliserTest.scala
+++ b/src/test/scala/gwen/dsl/SpecNormaliserTest.scala
@@ -27,7 +27,7 @@ class SpecNormaliserTest extends FlatSpec with Matchers with SpecNormaliser {
   "Feature with no step defs" should "normalise without error" in {
     val feature = FeatureSpec(
     Feature("feature1", Nil), None, List(
-      Scenario(Set[Tag](), "scenario1", Nil, None, List(
+      Scenario(List[Tag](), "scenario1", Nil, None, List(
         Step(StepKeyword.Given, "step 1", Passed(2)),
         Step(StepKeyword.Given, "step 2", Passed(1)),
         Step(StepKeyword.Given, "step 3", Passed(2)))
@@ -38,7 +38,7 @@ class SpecNormaliserTest extends FlatSpec with Matchers with SpecNormaliser {
   "Meta with one step def" should "normalise without error" in {
     val meta = FeatureSpec(
     Feature("meta1", Nil), None, List(
-      Scenario(Set[Tag]("@StepDef"), "stepdef1", Nil, None, List(
+      Scenario(List[Tag]("@StepDef"), "stepdef1", Nil, None, List(
         Step(StepKeyword.Given, "step 1", Passed(2)),
         Step(StepKeyword.When, "step 2", Passed(1)),
         Step(StepKeyword.Then, "step 3", Passed(2)))
@@ -49,12 +49,12 @@ class SpecNormaliserTest extends FlatSpec with Matchers with SpecNormaliser {
   "Meta with multiple unique step defs" should "normalise without error" in {
     val meta = FeatureSpec(
     Feature("meta1", Nil), None, List(
-      Scenario(Set[Tag]("@StepDef"), "stepdef1", Nil, None, List(
+      Scenario(List[Tag]("@StepDef"), "stepdef1", Nil, None, List(
         Step(StepKeyword.Given, "step 1", Passed(2)),
         Step(StepKeyword.When, "step 2", Passed(1)),
         Step(StepKeyword.Then, "step 3", Passed(2)))
       ),
-      Scenario(Set[Tag]("@StepDef"), "stepdef2", Nil, None, List(
+      Scenario(List[Tag]("@StepDef"), "stepdef2", Nil, None, List(
         Step(StepKeyword.Given, "step 1", Passed(2)),
         Step(StepKeyword.When, "step 2", Passed(1)),
         Step(StepKeyword.Then, "step 3", Passed(2)))
@@ -65,12 +65,12 @@ class SpecNormaliserTest extends FlatSpec with Matchers with SpecNormaliser {
   "Meta with duplicate step def" should "error" in {
     val meta = FeatureSpec(
     Feature("meta1", Nil), None, List(
-      Scenario(Set[Tag]("@StepDef"), "stepdef1", Nil, None, List(
+      Scenario(List[Tag]("@StepDef"), "stepdef1", Nil, None, List(
         Step(StepKeyword.Given, "step 1", Passed(2)),
         Step(StepKeyword.When, "step 2", Passed(1)),
         Step(StepKeyword.Then, "step 3", Passed(2)))
       ),
-      Scenario(Set[Tag]("@StepDef"), "stepdef1", Nil, None, List(
+      Scenario(List[Tag]("@StepDef"), "stepdef1", Nil, None, List(
         Step(StepKeyword.Given, "step 1", Passed(2)),
         Step(StepKeyword.When, "step 2", Passed(1)),
         Step(StepKeyword.Then, "step 3", Passed(2)))
@@ -84,12 +84,12 @@ class SpecNormaliserTest extends FlatSpec with Matchers with SpecNormaliser {
   "Meta with duplicate step def with params" should "error" in {
     val meta = FeatureSpec(
     Feature("meta1", Nil), None, List(
-      Scenario(Set[Tag]("@StepDef"), "stepdef <number>", Nil, None, List(
+      Scenario(List[Tag]("@StepDef"), "stepdef <number>", Nil, None, List(
         Step(StepKeyword.Given, "step 1", Passed(2)),
         Step(StepKeyword.When, "step 2", Passed(1)),
         Step(StepKeyword.Then, "step 3", Passed(2)))
       ),
-      Scenario(Set[Tag]("@StepDef"), "stepdef <index>", Nil, None, List(
+      Scenario(List[Tag]("@StepDef"), "stepdef <index>", Nil, None, List(
         Step(StepKeyword.Given, "step 1", Passed(2)),
         Step(StepKeyword.When, "step 2", Passed(1)),
         Step(StepKeyword.Then, "step 3", Passed(2)))
@@ -103,7 +103,7 @@ class SpecNormaliserTest extends FlatSpec with Matchers with SpecNormaliser {
   "Data driven feature with csv file" should "normalise without error" in {
     val feature = FeatureSpec(
     Feature("About me", Nil), None, List(
-      Scenario(Set[Tag](), "What am I?", Nil, None, List(
+      Scenario(List[Tag](), "What am I?", Nil, None, List(
         Step(StepKeyword.Given, "I am ${my age} year(s) old"),
         Step(StepKeyword.When, "I am a ${my gender}"),
         Step(StepKeyword.Then, "I am a ${my age} year old ${my title}"))
@@ -113,7 +113,7 @@ class SpecNormaliserTest extends FlatSpec with Matchers with SpecNormaliser {
     val result = normalise(feature, None, Some(dataRecord))
     result.feature.name should be ("About me, [1] my age=18..")
     result.scenarios.length should be (2)
-    result.scenarios(0).tags should be (Set(Tag("""Data(file="AboutMe.csv", record=1)""")))
+    result.scenarios(0).tags should be (List(Tag("""Data(file="AboutMe.csv", record=1)""")))
     result.scenarios(0).name should be ("Bind data attributes")
     result.scenarios(0).steps(0).toString should be ("""Given my age is "18"""")
     result.scenarios(0).steps(1).toString should be ("""And my gender is "male"""")

--- a/src/test/scala/gwen/eval/EnvContextTest.scala
+++ b/src/test/scala/gwen/eval/EnvContextTest.scala
@@ -40,7 +40,7 @@ class EnvContextTest extends FlatSpec with Matchers {
       Step(StepKeyword.And, """I submit the search field""")
     )
     
-    val stepdef = Scenario(Set(Tag("StepDef")), """I search for "gwen"""", Nil, None, steps)
+    val stepdef = Scenario(List(Tag("StepDef")), """I search for "gwen"""", Nil, None, steps)
     val env = newEnv
     env.addStepDef(stepdef)
     
@@ -56,7 +56,7 @@ class EnvContextTest extends FlatSpec with Matchers {
       Step(StepKeyword.And, """I submit the search field""")
     )
     
-    val stepdef = Scenario(Set(Tag("StepDef")), """I search for "gwen"""", Nil, None, steps)
+    val stepdef = Scenario(List(Tag("StepDef")), """I search for "gwen"""", Nil, None, steps)
     val env = newEnv
     env.addStepDef(stepdef)
     
@@ -68,11 +68,11 @@ class EnvContextTest extends FlatSpec with Matchers {
   
   "StepDef with params" should "resolve" in {
     
-    val stepdef1 = Scenario(Set(Tag("StepDef")), """I enter "<searchTerm>" in the search field""", Nil, None, Nil)
-    val stepdef2 = Scenario(Set(Tag("StepDef")), """I enter "<search term>" in the search field again""", Nil, None, Nil)
-    val stepdef3 = Scenario(Set(Tag("StepDef")), "z = <x> + 1", Nil, None, Nil)
-    val stepdef4 = Scenario(Set(Tag("StepDef")), "z = 1 + <x>", Nil, None, Nil)
-    val stepdef5 = Scenario(Set(Tag("StepDef")), "z = <x> - <y>", Nil, None, Nil)
+    val stepdef1 = Scenario(List(Tag("StepDef")), """I enter "<searchTerm>" in the search field""", Nil, None, Nil)
+    val stepdef2 = Scenario(List(Tag("StepDef")), """I enter "<search term>" in the search field again""", Nil, None, Nil)
+    val stepdef3 = Scenario(List(Tag("StepDef")), "z = <x> + 1", Nil, None, Nil)
+    val stepdef4 = Scenario(List(Tag("StepDef")), "z = 1 + <x>", Nil, None, Nil)
+    val stepdef5 = Scenario(List(Tag("StepDef")), "z = <x> - <y>", Nil, None, Nil)
     
     val env = newEnv
     env.addStepDef(stepdef1)
@@ -87,7 +87,7 @@ class EnvContextTest extends FlatSpec with Matchers {
     env.getStepDef("z = 1 + 3") should be (Some((stepdef4, List(("<x>", "3")))))
     env.getStepDef("z = 2 - 2") should be (Some((stepdef5, List(("<x>", "2"), ("<y>", "2")))))
 
-    val stepdef6 = Scenario(Set(Tag("StepDef")), "z = <x> * <x>", Nil, None, Nil)
+    val stepdef6 = Scenario(List(Tag("StepDef")), "z = <x> * <x>", Nil, None, Nil)
     env.addStepDef(stepdef6)
     intercept[AmbiguousCaseException] {
       env.getStepDef("z = 3 * 4")
@@ -97,9 +97,9 @@ class EnvContextTest extends FlatSpec with Matchers {
   
   "Sample math StepDefs with parameters" should "resolve" in {
     
-    val stepdef1 = Scenario(Set(Tag("StepDef")), "++x", Nil, None, Nil)
-    val stepdef2 = Scenario(Set(Tag("StepDef")), "c = a + <b>", Nil, None, Nil)
-    val stepdef3 = Scenario(Set(Tag("StepDef")), "z = <x> + <y>", Nil, None, Nil)
+    val stepdef1 = Scenario(List(Tag("StepDef")), "++x", Nil, None, Nil)
+    val stepdef2 = Scenario(List(Tag("StepDef")), "c = a + <b>", Nil, None, Nil)
+    val stepdef3 = Scenario(List(Tag("StepDef")), "z = <x> + <y>", Nil, None, Nil)
     
     val env = newEnv
     env.addStepDef(stepdef1)
@@ -117,8 +117,8 @@ class EnvContextTest extends FlatSpec with Matchers {
   
   "Ambiguous math StepDefs with parameters" should "be detected" in {
     
-    val stepdef1 = Scenario(Set(Tag("StepDef")), "z = a + <b>", Nil, None, Nil)
-    val stepdef2 = Scenario(Set(Tag("StepDef")), "z = <x> + <y>", Nil, None, Nil)
+    val stepdef1 = Scenario(List(Tag("StepDef")), "z = a + <b>", Nil, None, Nil)
+    val stepdef2 = Scenario(List(Tag("StepDef")), "z = <x> + <y>", Nil, None, Nil)
     
     val env = newEnv
     env.addStepDef(stepdef1)
@@ -241,7 +241,7 @@ class EnvContextTest extends FlatSpec with Matchers {
   "StepDef names" should "not start with a keyword" in {
     val env = newEnv
     StepKeyword.literals foreach { keyword =>
-      val stepdef = Scenario(Set(Tag("StepDef")), s"""$keyword I search for "gwen"""", Nil, None, Nil)
+      val stepdef = Scenario(List(Tag("StepDef")), s"""$keyword I search for "gwen"""", Nil, None, Nil)
       intercept[InvalidStepDefException] {
         env.addStepDef(stepdef)
       }

--- a/src/test/scala/gwen/eval/FeatureSummaryTest.scala
+++ b/src/test/scala/gwen/eval/FeatureSummaryTest.scala
@@ -68,12 +68,12 @@ class FeatureSummaryTest extends FlatSpec with Matchers {
     // add 1 meta
     val meta1 = FeatureSpec(
       Feature("meta1", Nil), None, List(
-        Scenario(Set[Tag](), "metaScenario1", Nil, None, List(
+        Scenario(List[Tag](), "metaScenario1", Nil, None, List(
           Step(StepKeyword.Given, "meta step 1", Passed2),
           Step(StepKeyword.Given, "meta step 2", Passed1),
           Step(StepKeyword.Given, "meta step 3", Passed2))
         ),
-        Scenario(Set(Tag("StepDef")), "metaStepDef1", Nil, None, List(
+        Scenario(List(Tag("StepDef")), "metaStepDef1", Nil, None, List(
           Step(StepKeyword.Given, "step 1", Loaded),
           Step(StepKeyword.Given, "step 2", Loaded),
           Step(StepKeyword.Given, "step 3", Loaded))
@@ -82,12 +82,12 @@ class FeatureSummaryTest extends FlatSpec with Matchers {
     // add 1 passed scenario
     val feature1 = FeatureSpec(
       Feature("feature1", Nil), None, List(
-        Scenario(Set[Tag](), "scenario1", Nil, None, List(
+        Scenario(List[Tag](), "scenario1", Nil, None, List(
           Step(StepKeyword.Given, "step 1", Passed2),
           Step(StepKeyword.Given, "step 2", Passed1),
           Step(StepKeyword.Given, "step 3", Passed2))
         ),
-        Scenario(Set(Tag("StepDef")), "StepDef1", Nil, None, List(
+        Scenario(List(Tag("StepDef")), "StepDef1", Nil, None, List(
           Step(StepKeyword.Given, "step 1", Loaded),
           Step(StepKeyword.Given, "step 2", Loaded),
           Step(StepKeyword.Given, "step 3", Loaded))
@@ -114,7 +114,7 @@ class FeatureSummaryTest extends FlatSpec with Matchers {
     // add 1 failed scenario
     val feature2 = FeatureSpec(
       Feature("feature2", Nil), None, List(
-        Scenario(Set[Tag](), "scenario1", Nil, None, List(
+        Scenario(List[Tag](), "scenario1", Nil, None, List(
           Step(StepKeyword.Given, "step 1", Passed2),
           Step(StepKeyword.Given, "step 2", Failed3),
           Step(StepKeyword.Given, "step 3", Skipped))
@@ -137,12 +137,12 @@ class FeatureSummaryTest extends FlatSpec with Matchers {
     // add 2 passed scenarios
     val feature3 = FeatureSpec(
       Feature("feature3", Nil), None, List(
-        Scenario(Set[Tag](), "scenario1", Nil, None, List(
+        Scenario(List[Tag](), "scenario1", Nil, None, List(
           Step(StepKeyword.Given, "step 1", Passed2),
           Step(StepKeyword.Given, "step 2", Passed1),
           Step(StepKeyword.Given, "step 3", Passed2))
         ), 
-        Scenario(Set[Tag](), "scenario2", Nil, None, List(
+        Scenario(List[Tag](), "scenario2", Nil, None, List(
           Step(StepKeyword.Given, "step 1", Passed2),
           Step(StepKeyword.Given, "step 2", Passed1),
           Step(StepKeyword.Given, "step 3", Passed2))
@@ -165,7 +165,7 @@ class FeatureSummaryTest extends FlatSpec with Matchers {
     // add 1 skipped scenario
     val feature4 = FeatureSpec(
       Feature("feature4", Nil), None, List(
-        Scenario(Set[Tag](), "scenario1", Nil, None, List(
+        Scenario(List[Tag](), "scenario1", Nil, None, List(
           Step(StepKeyword.Given, "step 1", Skipped),
           Step(StepKeyword.Given, "step 2", Skipped),
           Step(StepKeyword.Given, "step 3", Skipped))
@@ -188,7 +188,7 @@ class FeatureSummaryTest extends FlatSpec with Matchers {
     // add 1 pending scenario
     val feature5 = FeatureSpec(
       Feature("feature5", Nil), None, List(
-        Scenario(Set[Tag](), "scenario1", Nil, None, List(
+        Scenario(List[Tag](), "scenario1", Nil, None, List(
           Step(StepKeyword.Given, "step 1", Pending),
           Step(StepKeyword.Given, "step 2", Pending))
         )))
@@ -210,25 +210,25 @@ class FeatureSummaryTest extends FlatSpec with Matchers {
     // add 4 passed and 1 failed scenario
     val feature6 = FeatureSpec(
       Feature("feature6", Nil), None, List(
-        Scenario(Set[Tag](), "scenario1", Nil, None, List(
+        Scenario(List[Tag](), "scenario1", Nil, None, List(
           Step(StepKeyword.Given, "step 1", Passed2),
           Step(StepKeyword.Given, "step 2", Passed1),
           Step(StepKeyword.Given, "step 3", Passed2))
         ), 
-        Scenario(Set[Tag](), "scenario2", Nil, None, List(
+        Scenario(List[Tag](), "scenario2", Nil, None, List(
           Step(StepKeyword.Given, "step 1", Passed4),
           Step(StepKeyword.Given, "step 2", Passed1))
         ),
-        Scenario(Set[Tag](), "scenario3", Nil, None, List(
+        Scenario(List[Tag](), "scenario3", Nil, None, List(
           Step(StepKeyword.Given, "step 1", Passed2),
           Step(StepKeyword.Given, "step 2", Passed1),
           Step(StepKeyword.Given, "step 3", Passed2))
         ),
-        Scenario(Set[Tag](), "scenario4", Nil, None, List(
+        Scenario(List[Tag](), "scenario4", Nil, None, List(
           Step(StepKeyword.Given, "step 1", Passed2),
           Step(StepKeyword.Given, "step 2", Passed3))
         ),
-        Scenario(Set[Tag](), "scenario5", Nil, None, List(
+        Scenario(List[Tag](), "scenario5", Nil, None, List(
           Step(StepKeyword.Given, "step 1", Passed1),
           Step(StepKeyword.Given, "step 2", Failed4),
           Step(StepKeyword.Given, "step 3", Skipped),

--- a/src/test/scala/gwen/eval/GwenInterpreterTest.scala
+++ b/src/test/scala/gwen/eval/GwenInterpreterTest.scala
@@ -99,7 +99,7 @@ class GwenInterpreterTest extends FlatSpec with Matchers with MockitoSugar {
     val mockEnv = mock[EnvContext]
     val step1 = Step(StepKeyword.Given, "I am a step in the stepdef")
     val step2 = Step(StepKeyword.Given, "I am a valid stepdef")
-    val stepdef = Scenario(Set[Tag](Tag.StepDefTag), "I am a valid stepdef", Nil, None, List(step1))
+    val stepdef = Scenario(List[Tag](Tag.StepDefTag), "I am a valid stepdef", Nil, None, List(step1))
     when(mockEnv.getStepDef("I am a valid stepdef")).thenReturn(Some((stepdef, Nil)))
     when(mockEnv.getStepDef("I am a step in the stepdef")).thenReturn(None)
     when(mockEnv.attachments).thenReturn(Nil)
@@ -178,7 +178,7 @@ class GwenInterpreterTest extends FlatSpec with Matchers with MockitoSugar {
     val metaFile = writeToFile(metaString, createFile("test2.meta"))
     val featureFile = writeToFile(featureString, createFile("test2.feature"))
     val stepdef = Scenario(
-      Set[Tag](),
+      List[Tag](),
       "the butterfly flaps its wings", 
       Nil, 
       None, 

--- a/src/test/scala/gwen/eval/GwenInterpreterTest.scala
+++ b/src/test/scala/gwen/eval/GwenInterpreterTest.scala
@@ -196,6 +196,7 @@ class GwenInterpreterTest extends FlatSpec with Matchers with MockitoSugar {
     when(mockEnv.getStepDef("")).thenReturn(None)
     when(mockEnv.attachments).thenReturn(Nil)
     when(mockEnv.localScope).thenReturn(localScope)
+    when(mockEnv.loadedMeta).thenReturn(Nil)
     val step1 = Step(Position(4, 9), StepKeyword.Given, "I am an observer")
     val step2 = Step(Position(6, 9), StepKeyword.Given, "the butterfly flaps its wings")
     val step3 = Step(Position(5, 9), StepKeyword.Given, "a deterministic nonlinear system")

--- a/src/test/scala/gwen/eval/GwenLauncherTest.scala
+++ b/src/test/scala/gwen/eval/GwenLauncherTest.scala
@@ -46,7 +46,7 @@ class GwenLauncherTest extends FlatSpec with Matchers with MockitoSugar {
   val feature = new FeatureSpec(
       Feature("test-feature", Nil), 
       None, 
-      List(Scenario(Set[Tag](), "scenario1", Nil, None, List(Step(StepKeyword.Given, "I am a test", Passed(10)))))
+      List(Scenario(List[Tag](), "scenario1", Nil, None, List(Step(StepKeyword.Given, "I am a test", Passed(10)))))
   )
   val featureResult = FeatureResult(feature, None, Nil, Duration.Zero)
   
@@ -109,7 +109,7 @@ class GwenLauncherTest extends FlatSpec with Matchers with MockitoSugar {
     val meta = new FeatureSpec(
       Feature("meta feature", Nil), 
       None, 
-      List(Scenario(Set[Tag](), "scenario1", Nil, None, List(Step(StepKeyword.Given, "I am a meta step", Passed(10)))))
+      List(Scenario(List[Tag](), "scenario1", Nil, None, List(Step(StepKeyword.Given, "I am a meta step", Passed(10)))))
     )
     
     val mockInterpreter = mock[GwenInterpreter[EnvContext]]
@@ -140,7 +140,7 @@ class GwenLauncherTest extends FlatSpec with Matchers with MockitoSugar {
     val meta = new FeatureSpec(
       Feature("meta feature", Nil), 
       None, 
-      List(Scenario(Set[Tag](), "scenario1", Nil, None, List(Step(StepKeyword.Given, "I am a meta step", Passed(10)))))
+      List(Scenario(List[Tag](), "scenario1", Nil, None, List(Step(StepKeyword.Given, "I am a meta step", Passed(10)))))
     )
     
     val mockInterpreter = mock[GwenInterpreter[EnvContext]]
@@ -172,7 +172,7 @@ class GwenLauncherTest extends FlatSpec with Matchers with MockitoSugar {
     val meta = new FeatureSpec(
       Feature("meta feature", Nil), 
       None, 
-      List(Scenario(Set[Tag](), "scenario1", Nil, None, List(Step(StepKeyword.Given, "I am a meta step", Passed(10)))))
+      List(Scenario(List[Tag](), "scenario1", Nil, None, List(Step(StepKeyword.Given, "I am a meta step", Passed(10)))))
     )
     
     val mockInterpreter = mock[GwenInterpreter[EnvContext]]
@@ -199,7 +199,7 @@ class GwenLauncherTest extends FlatSpec with Matchers with MockitoSugar {
     val meta = new FeatureSpec(
       Feature("meta feature", Nil), 
       None, 
-      List(Scenario(Set[Tag](), "scenario1", Nil, None, List(Step(StepKeyword.Given, "I am a meta st ep", Failed(5, new Exception("failed"))))))
+      List(Scenario(List[Tag](), "scenario1", Nil, None, List(Step(StepKeyword.Given, "I am a meta st ep", Failed(5, new Exception("failed"))))))
     )
     
     val options = GwenOptions(batch = false, features = List(dir4))
@@ -234,7 +234,7 @@ class GwenLauncherTest extends FlatSpec with Matchers with MockitoSugar {
     val meta = new FeatureSpec(
       Feature("meta feature", Nil), 
       None, 
-      List(Scenario(Set[Tag](), "scenario1", Nil, None, List(Step(StepKeyword.Given, "I am a meta st ep", failedStatus))))
+      List(Scenario(List[Tag](), "scenario1", Nil, None, List(Step(StepKeyword.Given, "I am a meta st ep", failedStatus))))
     )
     
     val mockInterpreter = mock[GwenInterpreter[EnvContext]]
@@ -269,20 +269,20 @@ class GwenLauncherTest extends FlatSpec with Matchers with MockitoSugar {
     val feature6A = new FeatureSpec(
       Feature("test-feature-6a", Nil), 
       None, 
-      List(Scenario(Set[Tag](), "scenario6A", Nil, None, List(Step(StepKeyword.Given, "I am a test 6A", Passed(1000))))),
+      List(Scenario(List[Tag](), "scenario6A", Nil, None, List(Step(StepKeyword.Given, "I am a test 6A", Passed(1000))))),
       Some(feature6a)
     )
     val feature6B = new FeatureSpec(
       Feature("test-feature-6b", Nil), 
       None, 
-      List(Scenario(Set[Tag](), "scenario6B", Nil, None, List(Step(StepKeyword.Given, "I am a test 6B", Passed(2000))))),
+      List(Scenario(List[Tag](), "scenario6B", Nil, None, List(Step(StepKeyword.Given, "I am a test 6B", Passed(2000))))),
       Some(feature6b)
     )
     
     val feature7A = new FeatureSpec(
       Feature("test-feature-7a", Nil), 
       None, 
-      List(Scenario(Set[Tag](), "scenario7A", Nil, None, List(Step(StepKeyword.Given, "I am a test 7A", Passed(3000))))),
+      List(Scenario(List[Tag](), "scenario7A", Nil, None, List(Step(StepKeyword.Given, "I am a test 7A", Passed(3000))))),
       Some(feature7a)
     )
     

--- a/version.sbt
+++ b/version.sbt
@@ -1,6 +1,6 @@
 enablePlugins(GitVersioning)
 
-git.baseVersion := "1.3.5"
+git.baseVersion := "1.4.0"
 
 git.useGitDescribe := true
 


### PR DESCRIPTION
This feature adds support for explicitly importing meta files into feature files.  This is useful for cases where you have many meta files and it is not practical to load all of them for every feature file. It is also useful for cases where the current auto-meta-discovery and `-m` command line mechanisms are insufficient for controlling exactly what meta should be loaded when. 

You can now manage and control exactly what meta will be loaded by your features without ever having to specify that meta on the command line. This can help avoid redundant meta loads and also greatly improve performance and usability when you have a lot of meta spread across many files.

For example, say you have 10 meta files in a directory and you only want to load one of them when executing a feature. Previously, you could do this through the `-m` command line switch as follows:

```
gwen -m metadir/module1.meta test.feature
```

You could also load all 10 meta files as follows:

```
gwen -m metadir test.feature
```

Remembering exactly which meta to load for which features is impractical, and blindly loading all meta files to execute a feature that only uses one or some of them is wasteful.

With meta imports, we can do away with having to use the `-m` option altogether by adding the following annotation to the `Feature` declaration in each feature file. For example, we can declare what meta the `test.feature` file should load by specifying an import annotation in the feature file itself as follows:

_test.feature file_:
```
 @Import("metadir/module1.meta")
 Feature: test feature

Scenario: scenario 1
    Given I want ..
    ..
```

Now we can simply just specify the feature on the command line as follows:

```
gwen test.feature
```

Gwen will then load the meta file specified in the import before executing the steps in the feature.

You can add any number of meta imports to a feature. The following imports two meta files.

_test.feature file_:
```
 @Import("metadir/module1.meta")
 @Import("metadir/module2.meta")
 Feature: test feature

Scenario: scenario 1
    Given I want ..
    ..
```

You can also chain (or string together) meta imports across meta files. For example, if the `module2.meta` always requires `module1.meta`, then you can import the latter into the former:

 _metadir/module2.meta file_:
```
 @Import("metadir/module1.meta")
 Feature: module 2 meta

@StepDef
Scenario: ..
    Given I want ..
    ..
```

Now any feature that imports `module2.meta` will also implicitly import `module1.meta`. For example, if we declare `test.feature` to import `module2.meta` as follows:

_test.feature file_:
```
 @Import("metadir/module2.meta")
 Feature: test feature

Scenario: scenario 1
    Given I want ..
    ..
```

 ..Then both `module1.meta` and `module2.meta` will be loaded (in that order) when the feature is executed without you having to specify any meta on the command line:

```
gwen test.feature
```

The path to the meta file in all import annotations is relative to the working directory where Gwen is invoked.

If a recursive (or cyclic) import is detected in an import chain, Gwen will report it by throwing an exception with a message specifying which import annotation was the culprit and the file it was declared in.

Meta imports are always loaded before any auto discovered meta files or `-m` command line meta files are loaded, and therefore have the least precedence so their contents can be shadowed.