### PR TITLE
Data Tables

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 2.7.0
 =====
-Jun 30, 2017
+Jul 2, 2017
 - Add support for Gherkin data tables (horizontal and vertical orientations)
 
 2.6.1

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+2.7.0
+=====
+Jun 30, 2017
+- Add support for Gherkin data tables (horizontal and vertical orientations)
+
 2.6.1
 =====
 Jun 27, 2017

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 2.7.0
 =====
-Jul 2, 2017
-- Add support for Gherkin data tables (horizontal and vertical orientations)
+Jul 5, 2017
+- PR gwen-interpreter/gwen#32 - Add support for Gherkin data tables (horizontal, vertical, and matrix forms)
 
 2.6.1
 =====

--- a/README.md
+++ b/README.md
@@ -2,27 +2,51 @@
 Gwen
 ====
 
-Gwen is [Gherkin](https://github.com/cucumber/cucumber/wiki/Gherkin) interpreter that turns
-[Given-When-Then](https://github.com/cucumber/cucumber/wiki/Given-When-Then) steps into automation instructions and
-executes them for you so you don't have to do all the programming work. It has an abstracted
-[evaluation engine](https://github.com/gwen-interpreter/gwen/wiki/Evaluation-Engines)
-allowing any type of automation capability to be mixed in and reused. For example, we have built and
-shared a [web engine](https://github.com/gwen-interpreter/gwen-web) that you can download and use to automate web
-application testing and online web robotics.
-[Meta specifications](https://github.com/gwen-interpreter/gwen/wiki/Meta-Features) (also expressed in Gherkin) can be
-used to capture automation bindings and map high level feature steps to low level engine steps.
+Gwen is a [Gherkin](https://github.com/cucumber/cucumber/wiki/Gherkin) interpreter that turns [G]iven-[W]hen-Th[en]
+steps into automation instructions and executes them for you so you don't have to do all the programming work. It has
+an abstracted [evaluation engine](https://github.com/gwen-interpreter/gwen/wiki/Evaluation-Engines) allowing any type of
+automation capability to be mixed in and reused.
+[Meta specifications](https://github.com/gwen-interpreter/gwen/wiki/Meta-Features) (also expressed in Gherkin) are used
+to capture automation bindings and allow you to compose step definitions by mapping 'declarative' steps in features to
+'imperative' steps in
+[@StepDef scenarios](https://github.com/gwen-interpreter/gwen/wiki/Meta-Features#composable-step-definitions)
+that perform operations through pre-programmed automation engines.
 
 ### Current Status
 
 [![Build Status](https://travis-ci.org/gwen-interpreter/gwen.svg)](https://travis-ci.org/gwen-interpreter/gwen)
 
-- [Latest release](https://github.com/gwen-interpreter/gwen/releases/latest) 
+- [Latest release](https://github.com/gwen-interpreter/gwen/releases/latest)
 - [Change log](CHANGELOG)
+
+Why did we create Gwen?
+-----------------------
+
+> To drive automation with behavior instead of code.
+
+Most Gherkin tools and frameworks target BDD (Behavior Driven Development) and therefore adopt a very developer-centric
+or programmatic approach to verifying the behavior of code and driving its development. We wanted to build a BDA
+(Behavior Driven Automation) tool that could use Gherkin to automate acceptance testing and robotic processing instead
+with only little or no coding required on behalf of the user. So we built the Gwen interpreter to read Gherkin as input
+and produce executing instructions as output through automation engines that can be prebuilt with specific capabilities
+and mixed in. Our first such engine is the [gwen-web](https://github.com/gwen-interpreter/gwen-web) engine that we built
+on top of Selenium. You can download and use it to drive a web browser and automate web based activities without having
+to develop code to interact with Selenium.
+
+See also, our:
+- [Blog](https://gweninterpreter.wordpress.com)
+- [Wiki](https://github.com/gwen-interpreter/gwen/wiki)
+- and [FAQ](https://github.com/gwen-interpreter/gwen/wiki/FAQ)
+
+Core Runtime Requirement
+------------------------
+
+- Java SE 8 Runtime Environment
 
 Key Features
 ------------
 
-- [Gherkin grammar](https://github.com/gwen-interpreter/gwen/wiki/Supported-Grammar)
+- [Gherkin grammar](https://cucumber.io/docs/reference)
 - [Evaluation engines](https://github.com/gwen-interpreter/gwen/wiki/Evaluation-Engines)
 - [Evaluation reports](https://github.com/gwen-interpreter/gwen/wiki/Evaluation-Reports)
 - [Command line interface](https://github.com/gwen-interpreter/gwen/wiki/Command-Line-Interface)
@@ -38,29 +62,26 @@ Key Features
 - [String interpolation](https://github.com/gwen-interpreter/gwen/wiki/String-Interpolation)
 - [SQL data bindings](https://github.com/gwen-interpreter/gwen/wiki/SQL-Data-Bindings)
 
-Runtime Requirements
---------------------
-
-- Java SE 8 Runtime Environment
-
-Resources
----------
-
-  - [Wiki](https://github.com/gwen-interpreter/gwen/wiki) 
-  - [FAQ](https://github.com/gwen-interpreter/gwen/wiki/FAQ)
-  - [Blog](https://gweninterpreter.wordpress.com)
-
 Mail Group
 ----------
 
 All announcements and discussions are posted and broadcast to all members in the following mail group. You are welcome to visit and subscribe to receive notifications or get involved.
 
-- [gwen-interpreter](https://groups.google.com/d/forum/gwen-interpreter) 
+- [Our mail group](https://groups.google.com/d/forum/gwen-interpreter)
+
+Credits
+-------
+- Cucumber/Gherkin
+- Scopt
+- JLine
+- Bootstrap
+- JQuery
+- Reel
 
 Contributions
 -------------
 
-New capabilities, improvements, and fixes are all valid candidates for contribution. Submissions can be made using pull requests. Each submission 
+New capabilities, improvements, and fixes are all valid candidates for contribution. Submissions can be made using pull requests. Each submission
 is reviewed and verified by the project committers before being integrated and released to the community. We ask that all code submissions include unit tests.
 
 By submitting contributions, you agree to release your work under the license that covers this software.
@@ -77,12 +98,12 @@ License
 
 Copyright 2014-2017 Branko Juric, Brady Wood
 
-This software is open sourced under the 
+This software is open sourced under the
 [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt).
 
 See also: [LICENSE](LICENSE)
 
-This project has dependencies on other open source projects. All distributed third party depdendencies and their licenses are listed in the 
+This project has dependencies on other open source projects. All distributed third party depdendencies and their licenses are listed in the
 [LICENSE-THIRDPARTY](LICENSE-THIRDPARTY) file.
 
 Open sourced 14 May 2014 09:30 pm AEST

--- a/features/sample/tables/NumberTables.feature
+++ b/features/sample/tables/NumberTables.feature
@@ -16,16 +16,63 @@
 
  Feature: Number tables
 
-   Scenario: Horizontal data table
-       Given the word should match the number in each row
-             | one   | 1 |
-             | two   | 2 |
-             | three | 3 |
+   Scenario: Single record horizontal data table with no header
+       Given single row without header contains a number in decimal and binary form
+             | 3 | 11 |
 
-   Scenario: Vertical data table
-       Given the word should match the number in each column
-             | four | five | six |
-             | 4    | 5    | 6   |
+   Scenario: Single record horizontal data table with header
+       Given single row with header contains a number in decimal and binary form
+             | decimal | binary |
+             | 3       | 11     |
+
+   Scenario: Single record vertical data table with no header
+       Given single column without header contains a number in decimal and binary form
+             | 3  |
+             | 11 |
+
+   Scenario: Single record vertical data table with header
+       Given single column with header contains a number in decimal and binary form
+             | decimal | 3  |
+             | binary  | 11 |
+
+   Scenario: Horizontal table with header
+       Given each row contains a number and its square and cube
+             | number | square | cube |
+             | 1      | 1      | 1    |
+             | 2      | 4      | 8    |
+             | 3      | 9      | 27   |
+
+   Scenario: Horizontal data table with no header
+       Given each row contains a number in decimal and binary form
+             | 1 | 1  |
+             | 2 | 10 |
+             | 3 | 11 |
+
+   Scenario: Vertical table with header
+       Given each column contains a number and its square and cube
+             | number | 1 | 2 | 3  |
+             | square | 1 | 4 | 9  |
+             | cube   | 1 | 8 | 27 |
+
+   Scenario: Vertical data table with no header
+       Given each column contains a number in decimal and binary form
+             | 4   | 5    | 6   |
+             | 100 | 101  | 110 |
+
+   Scenario: Matrix table with top and left headers
+       Given the top and left numbers yield the product in the matrix
+             | x | 1 | 2 | 3 |
+             | 1 | 1 | 2 | 3 |
+             | 2 | 2 | 4 | 6 |
+             | 3 | 3 | 6 | 9 |
+
+   Scenario: Horizontal Fibonacci table with no header
+       Given each row contains two numbers that sum to a Fibonacci number in the third
+             | 0 | 1 | 1 |
+             | 1 | 1 | 2 |
+             | 1 | 2 | 3 |
+             | 2 | 3 | 5 |
+             | 3 | 5 | 8 |
 
    Scenario: tables in nested stepdefs should not conflict
        Given nested tables should match the right tables

--- a/features/sample/tables/NumberTables.feature
+++ b/features/sample/tables/NumberTables.feature
@@ -1,0 +1,31 @@
+#
+# Copyright 2017 Branko Juric, Brady Wood
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+ Feature: Number tables
+
+   Scenario: Horizontal data table
+       Given the word should match the number in each row
+             | one   | 1 |
+             | two   | 2 |
+             | three | 3 |
+
+   Scenario: Vertical data table
+       Given the word should match the number in each column
+             | four | five | six |
+             | 4    | 5    | 6   |
+
+   Scenario: tables in nested stepdefs should not conflict
+       Given nested tables should match the right tables

--- a/features/sample/tables/NumberTables.meta
+++ b/features/sample/tables/NumberTables.meta
@@ -1,0 +1,55 @@
+#
+# Copyright 2017 Branko Juric, Brady Wood
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+ Feature: Number tables meta
+
+  @StepDef
+  @DataTable(orientation="horizontal",data="word,number")
+  Scenario: the word should match the number in each row
+       Given data.word should be "one"
+        And data[0].word should be "one"
+        And data[1].word should be "two"
+        And data[2].word should be "three"
+        And data.number should be "1"
+        And data[0].number should be "1"
+        And data[1].number should be "2"
+        And data[2].number should be "3"
+
+  @StepDef
+  @DataTable(orientation="vertical",data="word,number")
+  Scenario: the word should match the number in each column
+      Given data.word should be "four"
+        And data[0].word should be "four"
+        And data[1].word should be "five"
+        And data[2].word should be "six"
+        And data.number should be "4"
+        And data[0].number should be "4"
+        And data[1].number should be "5"
+        And data[2].number should be "6"
+
+  @StepDef
+  Scenario: nested tables should match the right tables
+      Given the word should match the number in each row
+            | one   | 1 |
+            | two   | 2 |
+            | three | 3 |
+        And the nested table should match against its table
+
+  @StepDef
+  Scenario: the nested table should match against its table
+       Given the word should match the number in each column
+             | four | five | six |
+             | 4    | 5    | 6   |

--- a/features/sample/tables/NumberTables.meta
+++ b/features/sample/tables/NumberTables.meta
@@ -16,40 +16,175 @@
 
  Feature: Number tables meta
 
-  @StepDef
-  @DataTable(orientation="horizontal",data="word,number")
-  Scenario: the word should match the number in each row
-       Given data.word should be "one"
-        And data[0].word should be "one"
-        And data[1].word should be "two"
-        And data[2].word should be "three"
-        And data.number should be "1"
-        And data[0].number should be "1"
-        And data[1].number should be "2"
-        And data[2].number should be "3"
+   @StepDef
+   @DataTable(horizontal="decimal,binary")
+   Scenario: single row without header contains a number in decimal and binary form
+       Given data.decimal should be "3"
+         And data[1].decimal should be "3"
+         And data.binary should be "11"
+         And data[1].binary should be "11"
+         And the decimal data.decimal should be data.binary in binary for each data record
+
+   @StepDef
+   @DataTable(header="top")
+   Scenario: single row with header contains a number in decimal and binary form
+       Given data.decimal should be "3"
+         And data[1].decimal should be "3"
+         And data.binary should be "11"
+         And data[1].binary should be "11"
+         And the decimal data.decimal should be data.binary in binary for each data record
+
+   @StepDef
+   @DataTable(vertical="decimal,binary")
+   Scenario: single column without header contains a number in decimal and binary form
+       Given data.decimal should be "3"
+         And data[1].decimal should be "3"
+         And data.binary should be "11"
+         And data[1].binary should be "11"
+         And the decimal data.decimal should be data.binary in binary for each data record
+
+   @StepDef
+   @DataTable(header="left")
+   Scenario: single column with header contains a number in decimal and binary form
+       Given data.decimal should be "3"
+         And data[1].decimal should be "3"
+         And data.binary should be "11"
+         And data[1].binary should be "11"
+         And the decimal data.decimal should be data.binary in binary for each data record
 
   @StepDef
-  @DataTable(orientation="vertical",data="word,number")
-  Scenario: the word should match the number in each column
-      Given data.word should be "four"
-        And data[0].word should be "four"
-        And data[1].word should be "five"
-        And data[2].word should be "six"
-        And data.number should be "4"
-        And data[0].number should be "4"
-        And data[1].number should be "5"
-        And data[2].number should be "6"
+  @DataTable(horizontal="decimal,binary")
+  Scenario: each row contains a number in decimal and binary form
+      Given data.decimal should be "1"
+        And data[1].decimal should be "1"
+        And data[2].decimal should be "2"
+        And data[3].decimal should be "3"
+        And data.binary should be "1"
+        And data[1].binary should be "1"
+        And data[2].binary should be "10"
+        And data[3].binary should be "11"
+        And the decimal data.decimal should be data.binary in binary for each data record
+
+  @StepDef
+  @DataTable(vertical="decimal,binary")
+  Scenario: each column contains a number in decimal and binary form
+      Given data.decimal should be "4"
+        And data[1].decimal should be "4"
+        And data[2].decimal should be "5"
+        And data[3].decimal should be "6"
+        And data.binary should be "100"
+        And data[1].binary should be "100"
+        And data[2].binary should be "101"
+        And data[3].binary should be "110"
+        And the decimal data.decimal should be data.binary in binary for each data record
+
+  @StepDef
+  Scenario: the decimal <decimal> should be <binary> in binary
+     Given the result is defined by javascript "Number(${$<decimal>}).toString(2)"
+      Then the result should be "${$<binary>}"
+
+  @StepDef
+  @DataTable(header="top")
+  Scenario: each row contains a number and its square and cube
+      Given data.number should be "1"
+        And data[1].number should be "1"
+        And data[2].number should be "2"
+        And data[3].number should be "3"
+        And data.square should be "1"
+        And data[1].square should be "1"
+        And data[2].square should be "4"
+        And data[3].square should be "9"
+        And data.cube should be "1"
+        And data[1].cube should be "1"
+        And data[2].cube should be "8"
+        And data[3].cube should be "27"
+        And number ^ 2 = square of number for each data record
+        And number ^ 3 = cube of number for each data record
+
+  @StepDef
+  @DataTable(header="left")
+  Scenario: each column contains a number and its square and cube
+      Given data.number should be "1"
+        And data[1].number should be "1"
+        And data[2].number should be "2"
+        And data[3].number should be "3"
+        And data.square should be "1"
+        And data[1].square should be "1"
+        And data[2].square should be "4"
+        And data[3].square should be "9"
+        And data.cube should be "1"
+        And data[1].cube should be "1"
+        And data[2].cube should be "8"
+        And data[3].cube should be "27"
+        And number ^ 2 = square of number for each data record
+        And number ^ 3 = cube of number for each data record
+
+  @StepDef
+  Scenario: number ^ <power> = <function> of number
+      Given the result is defined by javascript "Math.pow(${data.number}, $<power>)"
+       Then the result should be "${data.$<function>}.0"
+
+  @StepDef
+  @DataTable(type="matrix")
+  Scenario: the top and left numbers yield the product in the matrix
+      Given top-left should be "x"
+        And top[1] should be "1"
+        And top[2] should be "2"
+        And top[3] should be "3"
+        And left[1] should be "1"
+        And left[2] should be "2"
+        And left[3] should be "3"
+        And data[1][1] should be "1"
+        And data[1][2] should be "2"
+        And data[1][3] should be "3"
+        And data[2][1] should be "2"
+        And data[2][2] should be "4"
+        And data[2][3] should be "6"
+        And data[3][1] should be "3"
+        And data[3][2] should be "6"
+        And data[3][3] should be "9"
+        And top[1] x left[1] = data[1][1]
+        And top[2] x left[1] = data[2][1]
+        And top[3] x left[1] = data[3][1]
+        And top[1] x left[2] = data[1][2]
+        And top[2] x left[2] = data[2][2]
+        And top[3] x left[2] = data[3][2]
+        And top[1] x left[3] = data[1][3]
+        And top[2] x left[3] = data[2][3]
+        And top[3] x left[3] = data[3][3]
+
+  @StepDef
+  Scenario: <a> x <b> = <c>
+      Given the product is defined by javascript "${$<a>} * ${$<b>}"
+       Then the product should be "${$<c>}"
+
+  @StepDef
+  @DataTable(horizontal="a,b,c")
+  Scenario: each row contains two numbers that sum to a Fibonacci number in the third
+      Given a + b = c for each data record
+       Then data[1].a should be "0"
+       Then data[1].b should be "1"
+        And data[1].c should be "1"
+        And data[2].c should be "2"
+        And data[3].c should be "3"
+        And data[4].c should be "5"
+        And data[5].c should be "8"
+
+  @StepDef
+  Scenario: a + b = c
+      Given the sum is defined by javascript "${data.a} + ${data.b}"
+       Then the sum should be "${data.c}"
 
   @StepDef
   Scenario: nested tables should match the right tables
-      Given the word should match the number in each row
-            | one   | 1 |
-            | two   | 2 |
-            | three | 3 |
+      Given each row contains a number in decimal and binary form
+             | 1 | 1  |
+             | 2 | 10 |
+             | 3 | 11 |
         And the nested table should match against its table
 
   @StepDef
   Scenario: the nested table should match against its table
-       Given the word should match the number in each column
-             | four | five | six |
-             | 4    | 5    | 6   |
+       Given each column contains a number in decimal and binary form
+             | 4   | 5    | 6   |
+             | 100 | 101  | 110 |

--- a/features/sample/tables/NumberTables.meta
+++ b/features/sample/tables/NumberTables.meta
@@ -19,121 +19,146 @@
    @StepDef
    @DataTable(horizontal="decimal,binary")
    Scenario: single row without header contains a number in decimal and binary form
-       Given data.decimal should be "3"
-         And data[1].decimal should be "3"
-         And data.binary should be "11"
-         And data[1].binary should be "11"
-         And the decimal data.decimal should be data.binary in binary for each data record
+       Given name[1] should be "decimal"
+         And name[2] should be "binary"
+         And data[decimal] should be "3"
+         And data[1][decimal] should be "3"
+         And data[binary] should be "11"
+         And data[1][binary] should be "11"
+         And the decimal data[decimal] should be data[binary] in binary for each data record
 
    @StepDef
    @DataTable(header="top")
    Scenario: single row with header contains a number in decimal and binary form
-       Given data.decimal should be "3"
-         And data[1].decimal should be "3"
-         And data.binary should be "11"
-         And data[1].binary should be "11"
-         And the decimal data.decimal should be data.binary in binary for each data record
+       Given name[1] should be "decimal"
+         And name[2] should be "binary"
+         And data[decimal] should be "3"
+         And data[1][decimal] should be "3"
+         And data[binary] should be "11"
+         And data[1][binary] should be "11"
+         And the decimal data[decimal] should be data[binary] in binary for each data record
 
    @StepDef
    @DataTable(vertical="decimal,binary")
    Scenario: single column without header contains a number in decimal and binary form
-       Given data.decimal should be "3"
-         And data[1].decimal should be "3"
-         And data.binary should be "11"
-         And data[1].binary should be "11"
-         And the decimal data.decimal should be data.binary in binary for each data record
+       Given name[1] should be "decimal"
+         And name[2] should be "binary"
+         And data[decimal] should be "3"
+         And data[1][decimal] should be "3"
+         And data[binary] should be "11"
+         And data[1][binary] should be "11"
+         And the decimal data[decimal] should be data[binary] in binary for each data record
 
    @StepDef
    @DataTable(header="left")
    Scenario: single column with header contains a number in decimal and binary form
-       Given data.decimal should be "3"
-         And data[1].decimal should be "3"
-         And data.binary should be "11"
-         And data[1].binary should be "11"
-         And the decimal data.decimal should be data.binary in binary for each data record
+       Given name[1] should be "decimal"
+         And name[2] should be "binary"
+         And data[decimal] should be "3"
+         And data[1][decimal] should be "3"
+         And data[binary] should be "11"
+         And data[1][binary] should be "11"
+         And the decimal data[decimal] should be data[binary] in binary for each data record
 
   @StepDef
   @DataTable(horizontal="decimal,binary")
   Scenario: each row contains a number in decimal and binary form
-      Given data.decimal should be "1"
-        And data[1].decimal should be "1"
-        And data[2].decimal should be "2"
-        And data[3].decimal should be "3"
-        And data.binary should be "1"
-        And data[1].binary should be "1"
-        And data[2].binary should be "10"
-        And data[3].binary should be "11"
-        And the decimal data.decimal should be data.binary in binary for each data record
+      Given name[1] should be "decimal"
+        And name[2] should be "binary"
+        And data[decimal] should be "1"
+        And data[1][decimal] should be "1"
+        And data[2][decimal] should be "2"
+        And data[3][decimal] should be "3"
+        And data[binary] should be "1"
+        And data[1][binary] should be "1"
+        And data[2][binary] should be "10"
+        And data[3][binary] should be "11"
+        And the decimal data[decimal] should be data[binary] in binary for each data record
 
   @StepDef
   @DataTable(vertical="decimal,binary")
   Scenario: each column contains a number in decimal and binary form
-      Given data.decimal should be "4"
-        And data[1].decimal should be "4"
-        And data[2].decimal should be "5"
-        And data[3].decimal should be "6"
-        And data.binary should be "100"
-        And data[1].binary should be "100"
-        And data[2].binary should be "101"
-        And data[3].binary should be "110"
-        And the decimal data.decimal should be data.binary in binary for each data record
+      Given name[1] should be "decimal"
+        And name[2] should be "binary"
+        And data[decimal] should be "4"
+        And data[1][decimal] should be "4"
+        And data[2][decimal] should be "5"
+        And data[3][decimal] should be "6"
+        And data[binary] should be "100"
+        And data[1][binary] should be "100"
+        And data[2][binary] should be "101"
+        And data[3][binary] should be "110"
+        And the decimal data[decimal] should be data[binary] in binary for each data record
 
   @StepDef
   Scenario: the decimal <decimal> should be <binary> in binary
      Given the result is defined by javascript "Number(${$<decimal>}).toString(2)"
       Then the result should be "${$<binary>}"
+       And name[1] should be "decimal"
+       And name[2] should be "binary"
+       And record.number should match regex "\d+"
 
   @StepDef
   @DataTable(header="top")
   Scenario: each row contains a number and its square and cube
-      Given data.number should be "1"
-        And data[1].number should be "1"
-        And data[2].number should be "2"
-        And data[3].number should be "3"
-        And data.square should be "1"
-        And data[1].square should be "1"
-        And data[2].square should be "4"
-        And data[3].square should be "9"
-        And data.cube should be "1"
-        And data[1].cube should be "1"
-        And data[2].cube should be "8"
-        And data[3].cube should be "27"
+      Given name[1] should be "number"
+        And name[2] should be "square"
+        And name[3] should be "cube"
+        And data[number] should be "1"
+        And data[1][number] should be "1"
+        And data[2][number] should be "2"
+        And data[3][number] should be "3"
+        And data[square] should be "1"
+        And data[1][square] should be "1"
+        And data[2][square] should be "4"
+        And data[3][square] should be "9"
+        And data[cube] should be "1"
+        And data[1][cube] should be "1"
+        And data[2][cube] should be "8"
+        And data[3][cube] should be "27"
         And number ^ 2 = square of number for each data record
         And number ^ 3 = cube of number for each data record
 
   @StepDef
   @DataTable(header="left")
   Scenario: each column contains a number and its square and cube
-      Given data.number should be "1"
-        And data[1].number should be "1"
-        And data[2].number should be "2"
-        And data[3].number should be "3"
-        And data.square should be "1"
-        And data[1].square should be "1"
-        And data[2].square should be "4"
-        And data[3].square should be "9"
-        And data.cube should be "1"
-        And data[1].cube should be "1"
-        And data[2].cube should be "8"
-        And data[3].cube should be "27"
+      Given name[1] should be "number"
+        And name[2] should be "square"
+        And name[3] should be "cube"
+        And data[number] should be "1"
+        And data[1][number] should be "1"
+        And data[2][number] should be "2"
+        And data[3][number] should be "3"
+        And data[square] should be "1"
+        And data[1][square] should be "1"
+        And data[2][square] should be "4"
+        And data[3][square] should be "9"
+        And data[cube] should be "1"
+        And data[1][cube] should be "1"
+        And data[2][cube] should be "8"
+        And data[3][cube] should be "27"
         And number ^ 2 = square of number for each data record
         And number ^ 3 = cube of number for each data record
 
   @StepDef
   Scenario: number ^ <power> = <function> of number
-      Given the result is defined by javascript "Math.pow(${data.number}, $<power>)"
-       Then the result should be "${data.$<function>}.0"
+      Given the result is defined by javascript "Math.pow(${data[number]}, $<power>)"
+       Then the result should be "${data[$<function>]}.0"
+        And name[1] should be "number"
+        And name[2] should be "square"
+        And name[3] should be "cube"
+        And record.number should match regex "\d+"
 
   @StepDef
   @DataTable(type="matrix")
   Scenario: the top and left numbers yield the product in the matrix
-      Given top-left should be "x"
-        And top[1] should be "1"
-        And top[2] should be "2"
-        And top[3] should be "3"
-        And left[1] should be "1"
-        And left[2] should be "2"
-        And left[3] should be "3"
+      Given vertex.name should be "x"
+        And top.name[1] should be "1"
+        And top.name[2] should be "2"
+        And top.name[3] should be "3"
+        And left.name[1] should be "1"
+        And left.name[2] should be "2"
+        And left.name[3] should be "3"
         And data[1][1] should be "1"
         And data[1][2] should be "2"
         And data[1][3] should be "3"
@@ -143,15 +168,15 @@
         And data[3][1] should be "3"
         And data[3][2] should be "6"
         And data[3][3] should be "9"
-        And top[1] x left[1] = data[1][1]
-        And top[2] x left[1] = data[2][1]
-        And top[3] x left[1] = data[3][1]
-        And top[1] x left[2] = data[1][2]
-        And top[2] x left[2] = data[2][2]
-        And top[3] x left[2] = data[3][2]
-        And top[1] x left[3] = data[1][3]
-        And top[2] x left[3] = data[2][3]
-        And top[3] x left[3] = data[3][3]
+        And top.name[1] x left.name[1] = data[1][1]
+        And top.name[2] x left.name[1] = data[2][1]
+        And top.name[3] x left.name[1] = data[3][1]
+        And top.name[1] x left.name[2] = data[1][2]
+        And top.name[2] x left.name[2] = data[2][2]
+        And top.name[3] x left.name[2] = data[3][2]
+        And top.name[1] x left.name[3] = data[1][3]
+        And top.name[2] x left.name[3] = data[2][3]
+        And top.name[3] x left.name[3] = data[3][3]
 
   @StepDef
   Scenario: <a> x <b> = <c>
@@ -162,18 +187,24 @@
   @DataTable(horizontal="a,b,c")
   Scenario: each row contains two numbers that sum to a Fibonacci number in the third
       Given a + b = c for each data record
-       Then data[1].a should be "0"
-       Then data[1].b should be "1"
-        And data[1].c should be "1"
-        And data[2].c should be "2"
-        And data[3].c should be "3"
-        And data[4].c should be "5"
-        And data[5].c should be "8"
+       Then name[1] should be "a"
+        And name[2] should be "b"
+        And name[3] should be "c"
+        And data[a] should be "0"
+        And data[b] should be "1"
+        And data[c] should be "1"
+        And data[1][a] should be "0"
+        And data[1][b] should be "1"
+        And data[1][c] should be "1"
+        And data[2][c] should be "2"
+        And data[3][c] should be "3"
+        And data[4][c] should be "5"
+        And data[5][c] should be "8"
 
   @StepDef
   Scenario: a + b = c
-      Given the sum is defined by javascript "${data.a} + ${data.b}"
-       Then the sum should be "${data.c}"
+      Given the sum is defined by javascript "${data[a]} + ${data[b]}"
+       Then the sum should be "${data[c]}"
 
   @StepDef
   Scenario: nested tables should match the right tables

--- a/src/main/resources/gwen/report/html/css/gwen.css
+++ b/src/main/resources/gwen/report/html/css/gwen.css
@@ -254,3 +254,7 @@ table tbody.summary td {
 .list-group {
   padding-left: 2px;
 }
+
+.data-table {
+  color: #333333;
+}

--- a/src/main/scala/gwen/Predefs.scala
+++ b/src/main/scala/gwen/Predefs.scala
@@ -217,6 +217,7 @@ object Predefs extends LazyLogging {
     def escapeHtml(text: String): String = StringEscapeUtils.escapeHtml4(text)
     def escapeXml(text: String): String = StringEscapeUtils.escapeXml10(text)
     def escapeJson(text: String): String = StringEscapeUtils.escapeJson(text)
+    def rightPad(str: String, size: Int): String = if (str.length < size) rightPad(str + " ", size) else str
 
     def resolveParams(source: String, params: List[(String, String)]): String = {
       params match {
@@ -226,7 +227,10 @@ object Predefs extends LazyLogging {
           resolveParams(source.replaceAll(s"<$name>", value), tail)
       }
     }
-    def formatDataRecord(record: List[String]): String = s"| ${record.mkString(" | ")} |"
+    def formatTableRow(table: List[(Int, List[String])], rowIndex: Int): String = {
+      val maxWidths = (table map { case (_, rows) => rows.map(_.length) }).transpose.map(_.max)
+      s"| ${(table(rowIndex)._2.zipWithIndex map { case (data, dataIndex) => s"${rightPad(data, maxWidths(dataIndex))}" }).mkString(" | ") } |"
+    }
   }
   
   object DurationOps {

--- a/src/main/scala/gwen/dsl/DataTable.scala
+++ b/src/main/scala/gwen/dsl/DataTable.scala
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2017 Branko Juric, Brady Wood
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gwen.dsl
+
+import gwen.errors.{dataTableError, syntaxError}
+import gwen.eval.ScopedData
+import gwen.Predefs.Kestrel
+
+/**
+  * Enumeration of supported table types.
+  *
+  * @author Branko Juric
+  */
+object TableType extends Enumeration {
+  val horizontal, vertical, matrix = Value
+}
+
+/**
+  * Data table containing records.
+  */
+trait DataTable {
+  val records: List[List[String]]
+  def tableScope: ScopedData
+}
+
+/**
+  * Models a flat data table with a associated data names.
+  *
+  * @param records list of records containing the data
+  * @param names list of data element names
+  */
+class FlatTable(val records: List[List[String]], val names: List[String]) extends DataTable {
+
+  /**
+    * Binds each data element to a new scope as 'data[recordNo].name' where
+    * - recordNo is the record number starting at 1
+    * - name is the associated data name
+    */
+  def tableScope: ScopedData = new ScopedData("table") tap { data =>
+    records.zipWithIndex foreach { case (record, rIndex) =>
+      names.zip(record) foreach { case (name, value) =>
+        if (rIndex == 0) data.set(s"data.$name", value)
+        data.set(s"data[${rIndex + 1}].$name", value)
+      }
+    }
+  }
+
+  /**
+    * Binds each data element in a record to a new scope as 'data[recordNo][name]' where
+    * - recordNo is the record number starting at 1
+    * - name is the associated data name
+    *
+    * @param recordIndex the record index
+    */
+  def recordScope(recordIndex: Int): ScopedData = new ScopedData("record") tap { data =>
+    names.zip(records(recordIndex)) foreach { case (name, value) =>
+      data.set(s"data.$name", value)
+    }
+  }
+
+}
+
+/**
+  * Models a matrix data table with row and column data names.
+  *
+  * @param records list of records containing the data
+  * @param names list of top and left header pairs (excluding overlapping top-left)
+  * @param topLeft the top-left matrix value
+  */
+class MatrixTable(val records: List[List[String]], val names: List[(String, String)], val topLeft: String) extends DataTable {
+
+  /**
+    * Binds each data element to a new scope as 'data[topName][leftName]' where
+    * - topName is the associated top header name
+    * - leftName is the associated left header name
+    */
+  def tableScope: ScopedData = new ScopedData("table") tap { data =>
+    data.set("top-left", topLeft)
+    val topNames = names.map(_._1)
+    val leftNames = names.map(_._2)
+    topNames.zipWithIndex foreach { case (topName, topIndex) =>
+      data.set(s"top[${topIndex + 1}]", topName)
+    }
+    leftNames.zipWithIndex foreach { case (leftName, leftIndex) =>
+      data.set(s"left[${leftIndex + 1}]", leftName)
+    }
+    records.zipWithIndex foreach { case (record, leftIndex) =>
+      record.zipWithIndex foreach { case (value, topIndex) =>
+        data.set(s"data[${topNames(topIndex)}][${leftNames(leftIndex)}]", value)
+      }
+    }
+  }
+}
+
+/**
+  * Data table factory.
+  */
+object DataTable {
+
+  import gwen.Predefs.RegexContext
+
+  def apply(tag: Tag, step: Step): DataTable = {
+    tag.name.trim match {
+      case r"""DataTable\(horizontal="(.*?)"$namesCSV\)""" =>
+        DataTable(step.table.map(_._2), TableType.horizontal, namesCSV.split(",").toList)
+      case r"""DataTable\(vertical="(.*?)"$namesCSV\)""" =>
+        DataTable(step.table.map(_._2), TableType.vertical, namesCSV.split(",").toList)
+      case r"""DataTable\(header="(top|left)"$header\)""" =>
+        DataTable(step.table.map(_._2), if (header == "top") TableType.horizontal else TableType.vertical, Nil)
+      case r"""DataTable\(type="matrix"\)""" =>
+        DataTable(step.table.map(_._2), TableType.matrix, Nil)
+      case _ => syntaxError(
+        s"""Invalid tag syntax: $tag - correct table tags include: DataTable(horizontal|vertical="name1,name2..,nameN"), DataTable(header="top|left"), DataTable(type="matrix")""")
+    }
+  }
+
+  /**
+    * Creates a data table.
+    *
+    * @param rawTable the raw data table
+    * @param tableType the table type (horizontal, vertical, or matrix)
+    * @param headers list of header names
+    */
+  def apply(rawTable: List[List[(String)]], tableType: TableType.Value, headers: List[String]) = {
+
+    if (rawTable.isEmpty)
+      dataTableError(s"Data table expected for StepDef with @DataTable annotation")
+
+    val table = if (tableType == TableType.vertical) rawTable.transpose else rawTable
+
+    if (headers.isEmpty && table.size < 2)
+      dataTableError(s"Table with header has no records")
+    if (headers.nonEmpty && headers.size != table.head.size)
+      dataTableError(s"${table.head.size} data names expected for $tableType data table but got ${headers.size}: '${headers}'")
+
+    tableType match {
+      case TableType.matrix =>
+        val topHeaders = table.head.tail
+        val leftHeaders = table.transpose.head.tail
+        val records = table.tail.map(_.tail)
+        new MatrixTable(records, topHeaders zip leftHeaders, table.head(0))
+      case _ =>
+        if (headers.nonEmpty) new FlatTable(table, headers)
+        else new FlatTable(table.tail, table.head)
+    }
+  }
+}
+
+

--- a/src/main/scala/gwen/dsl/DataTable.scala
+++ b/src/main/scala/gwen/dsl/DataTable.scala
@@ -17,7 +17,6 @@ package gwen.dsl
 
 import gwen.errors.{dataTableError, syntaxError}
 import gwen.eval.ScopedData
-import gwen.Predefs.Kestrel
 
 /**
   * Enumeration of supported table types.
@@ -62,35 +61,31 @@ trait DataTable {
 class FlatTable(val records: List[List[String]], val names: List[String]) extends DataTable {
 
   /**
-    * Binds each data element to a new scope as 'data[recordNo][name]' where
-    * - recordNo is the record number starting at 1
-    * - name is the associated data name
+    * Binds each data element to a new table scope for accessing the values.
     */
-  def tableScope: ScopedData = new ScopedData("table") tap { data =>
-    names.zipWithIndex foreach { case (name, index) =>
-      data.set(s"name[${index + 1}]", name)
-    }
-    records.zipWithIndex foreach { case (record, rIndex) =>
-      names.zip(record) foreach { case (name, value) =>
-        if (rIndex == 0) data.set(s"data[$name]", value)
-        data.set(s"data[${rIndex + 1}][$name]", value)
-      }
-    }
+  def tableScope : ScopedData = new ScopedData("table") {
+    override def isEmpty: Boolean = records.isEmpty
+    override def findEntries(pred: ((String, String)) => Boolean): Seq[(String, String)] =
+      ((names.zipWithIndex map { case (name, index) =>
+        (s"name[${index + 1}]", name)
+      }) ++ (records.zipWithIndex flatMap { case (record, rIndex) =>
+        names.zip(record) flatMap { case (name, value) =>
+          (s"data[${rIndex + 1}][$name]", value) :: (if (rIndex == 0) List((s"data[$name]", value)) else Nil)
+        }
+      })).filter(pred)
   }
 
   /**
-    * Binds each data element in a record to a new scope as 'data[name]' where
-    * - recordNo is the record number starting at 1
-    * - name is the associated data name
+    * Binds each data element in a record to a new for accessing values.
     *
     * @param recordIndex the record index
     */
-  def recordScope(recordIndex: Int): ScopedData = new ScopedData("record") tap { data =>
-    data.set(s"record.number", s"${recordIndex + 1}")
-    names.zip(records(recordIndex).zipWithIndex) foreach { case (name, (value, nameIndex)) =>
-      data.set(s"name[${nameIndex + 1}]", name)
-      data.set(s"data[$name]", value)
-    }
+  def recordScope(recordIndex: Int): ScopedData = new ScopedData("record") {
+    override def isEmpty: Boolean = records.isEmpty
+    override def findEntries(pred: ((String, String)) => Boolean): Seq[(String, String)] =
+      (("record.number", s"${recordIndex + 1}") :: (names.zip(records(recordIndex).zipWithIndex) flatMap { case (name, (value, nameIndex)) =>
+          List((s"name[${nameIndex + 1}]", name), (s"data[$name]", value))
+        })).filter(pred)
   }
 
 }
@@ -106,24 +101,22 @@ class FlatTable(val records: List[List[String]], val names: List[String]) extend
 class MatrixTable(val records: List[List[String]], val topNames: List[String], val leftNames: List[String], val vertexName: String) extends DataTable {
 
   /**
-    * Binds each data element to a new scope as 'data[topName][leftName]' where
-    * - topName is the associated top header name
-    * - leftName is the associated left header name
+    * Binds each data element to a new table scope for accessing the values.
     */
-  def tableScope: ScopedData = new ScopedData("table") tap { data =>
-    data.set("vertex.name", vertexName)
-    topNames.zipWithIndex foreach { case (topName, topIndex) =>
-      data.set(s"top.name[${topIndex + 1}]", topName)
-    }
-    leftNames.zipWithIndex foreach { case (leftName, leftIndex) =>
-      data.set(s"left.name[${leftIndex + 1}]", leftName)
-    }
-    records.zipWithIndex foreach { case (record, leftIndex) =>
-      record.zipWithIndex foreach { case (value, topIndex) =>
-        data.set(s"data[${topNames(topIndex)}][${leftNames(leftIndex)}]", value)
-      }
-    }
+  def tableScope : ScopedData = new ScopedData("table") {
+    override def isEmpty: Boolean = records.isEmpty
+    override def findEntries(pred: ((String, String)) => Boolean): Seq[(String, String)] =
+      ((("vertex.name", vertexName) :: (topNames.zipWithIndex map { case (topName, topIndex) =>
+        (s"top.name[${topIndex + 1}]", topName)
+      })) ++ (leftNames.zipWithIndex map { case (leftName, leftIndex) =>
+        (s"left.name[${leftIndex + 1}]", leftName)
+      }) ++ (records.zipWithIndex flatMap { case (record, leftIndex) =>
+        record.zipWithIndex map { case (value, topIndex) =>
+          (s"data[${topNames(topIndex)}][${leftNames(leftIndex)}]", value)
+        }
+      })).filter(pred)
   }
+
 }
 
 /**

--- a/src/main/scala/gwen/dsl/GwenModel.scala
+++ b/src/main/scala/gwen/dsl/GwenModel.scala
@@ -310,7 +310,7 @@ object Tag {
   val InbuiltTags = List("StepDef", "Import", "ForEach", "DataTable")
   val StepDefTag = Tag("StepDef")
   val ForEachTag = Tag("ForEach")
-  private val Regex = """~?@(\w+)""".r
+  private val Regex = """~?@([^\s]+)""".r
 
   import scala.language.implicitConversions
 

--- a/src/main/scala/gwen/dsl/GwenModel.scala
+++ b/src/main/scala/gwen/dsl/GwenModel.scala
@@ -301,27 +301,30 @@ case class Tag(name: String) extends SpecNode {
   
   /** Returns a string representation of this tag. */
   override def toString = s"@$name"
+
+  def isInBuilt = Tag.InbuiltTags.exists(name.startsWith(_))
   
 }
 object Tag {
-  
+
+  val InbuiltTags = List("StepDef", "Import", "ForEach", "DataTable")
   val StepDefTag = Tag("StepDef")
   val ForEachTag = Tag("ForEach")
   private val Regex = """~?@(\w+)""".r
-  
+
   import scala.language.implicitConversions
-  
+
   /**
     * Implicitly converts a tag string to a tag object.
-    * 
+    *
     *  @param value the string value to convert
-    *  @throws gwen.errors.InvalidTagException if the tag string is invalid 
+    *  @throws gwen.errors.InvalidTagException if the tag string is invalid
     */
   implicit def string2Tag(value: String): Tag = value match {
     case Regex(name) => Tag(name)
     case _ => invalidTagError(value)
   }
-  
+
   def apply(tag: gherkin.ast.Tag): Tag =
     (if (tag.getName.startsWith("@")) Tag(tag.getName.substring(1))
     else Tag(tag.getName)) tap { t => t.pos = Position(tag.getLocation) }
@@ -336,6 +339,7 @@ object Tag {
   * @param status optional evaluation status (default = Pending)
   * @param attachments file attachments as name-file pairs (default = Nil)
   * @param stepDef optional evaluated step def
+  * @param table data table (List of tuples of line position and rows of data)
   *    
   * @author Branko Juric
   */
@@ -344,7 +348,8 @@ case class Step(
     expression: String, 
     status: EvalStatus = Pending, 
     attachments: List[(String, File)] = Nil,
-    stepDef: Option[Scenario] = None) extends SpecNode {
+    stepDef: Option[Scenario] = None,
+    table: List[(Int, List[String])] = Nil) extends SpecNode {
   
   /** Returns the evaluation status of this step definition. */
   override lazy val evalStatus: EvalStatus = status
@@ -358,21 +363,27 @@ case class Step(
 }
 
 object Step {
-  def apply(step: gherkin.ast.Step): Step =
-    new Step(StepKeyword.names(step.getKeyword.trim), step.getText) tap { s => s.pos = Position(step.getLocation) }
+  def apply(step: gherkin.ast.Step): Step = {
+    val dataTable = Option(step.getArgument).filter(_.isInstanceOf[gherkin.ast.DataTable]).map(_.asInstanceOf[gherkin.ast.DataTable]) map { dt =>
+      dt.getRows.asScala.toList map { row =>
+        (row.getLocation.getLine, row.getCells.asScala.toList.map(_.getValue))
+      }
+    } getOrElse(Nil)
+    new Step(StepKeyword.names(step.getKeyword.trim), step.getText, table = dataTable) tap { s => s.pos = Position(step.getLocation) }
+  }
   def apply(pos: Position, keyword: StepKeyword.Value, expression: String): Step =
     new Step(keyword, expression) tap { s => s.pos = pos }
   def apply(pos: Position, keyword: StepKeyword.Value, expression: String, status: EvalStatus): Step =
     new Step(keyword, expression, status) tap { s => s.pos = pos }
   def apply(step: Step, pos: Position): Step =
-    new Step(step.keyword, step.expression, step.status, step.attachments, step.stepDef) tap { s => s.pos = pos}
+    new Step(step.keyword, step.expression, step.status, step.attachments, step.stepDef, step.table) tap { s => s.pos = pos}
   def apply(step: Step, expression: String): Step =
-    new Step(step.keyword, expression, step.status, step.attachments) tap { s => s.pos = step.pos}
+    new Step(step.keyword, expression, step.status, step.attachments, table = step.table) tap { s => s.pos = step.pos}
   def apply(step: Step, stepDef: Scenario): Step =
-    new Step(step.keyword, step.expression, stepDef.evalStatus, stepDef.steps.flatMap(_.attachments), Some(stepDef)) tap { s => s.pos = step.pos }
+    new Step(step.keyword, step.expression, stepDef.evalStatus, stepDef.steps.flatMap(_.attachments), Some(stepDef), step.table) tap { s => s.pos = step.pos }
   def apply(step: Step, status: EvalStatus, attachments: List[(String, File)]): Step =
-    new Step(step.keyword, step.expression, status, attachments, step.stepDef) tap { s => s.pos = step.pos }
+    new Step(step.keyword, step.expression, status, attachments, step.stepDef, step.table) tap { s => s.pos = step.pos }
   def apply(step: Step, status: EvalStatus, attachments: List[(String, File)], foreachStepDef: Scenario): Step =
-    new Step(step.keyword, step.expression, status, attachments, Some(foreachStepDef)) tap { s => s.pos = step.pos }
+    new Step(step.keyword, step.expression, status, attachments, Some(foreachStepDef), step.table) tap { s => s.pos = step.pos }
 }
 

--- a/src/main/scala/gwen/dsl/PrettyPrinter.scala
+++ b/src/main/scala/gwen/dsl/PrettyPrinter.scala
@@ -50,11 +50,11 @@ object prettyPrint {
       background.map(apply).getOrElse("") +
         (if (isOutline && scenario.examples.flatMap(_.scenarios).nonEmpty) "" else s"\n\n${formatTags("  ", tags)}  ${scenario.keyword}: $name${formatTextLines(description)}${formatStatus(scenario.evalStatus)}\n" + printAll(steps.map(apply), "  ", "\n")) +
         printAll(examples.map(apply), "", "\n")
-    case Step(keyword, expression, evalStatus, _, _) =>
-      rightJustify(keyword.toString) + s"$keyword $expression${formatStatus(evalStatus)}"
+    case Step(keyword, expression, evalStatus, _, _, table) =>
+      rightJustify(keyword.toString) + s"$keyword $expression${formatStatus(evalStatus)}" + s"${if (table.nonEmpty) formatTextLines(table.indices.toList.map { rowIndex => Formatting.formatTableRow(table, rowIndex) }) else ""}"
     case Examples(name, description, table, scenarios) => scenarios match {
       case Nil =>
-        s"\n  ${Examples.keyword}: $name${formatTextLines(description)}${formatTextLines(table.map { case (_, data) => Formatting.formatDataRecord(data) })}"
+        s"\n  ${Examples.keyword}: $name${formatTextLines(description)}${formatTextLines(table.indices.toList.map { rowIndex => Formatting.formatTableRow(table, rowIndex) })}"
       case _ =>
         scenarios.map(apply).mkString("")
     }

--- a/src/main/scala/gwen/errors.scala
+++ b/src/main/scala/gwen/errors.scala
@@ -52,6 +52,7 @@ package gwen {
     def recursiveImportError(importTag: Tag, specFile: File) = throw new RecursiveImportException(importTag, specFile)
     def syntaxError(msg: String) = throw new SyntaxException(msg)
     def sqlError(msg: String) = throw new SQLException(msg)
+    def dataTableError(msg: String) = throw new DataTableException(msg)
 
     /** Thrown when a parsing error occurs. */
     class ParsingException(msg: String, cause: Throwable) extends Exception(msg, cause)
@@ -123,6 +124,9 @@ package gwen {
     
     /** Thrown when an SQL error is detected. */
     class SQLException(msg: String) extends Exception(msg)
+
+    /** Thrown when a data table error is detected. */
+    class DataTableException(msg: String) extends Exception(msg)
 
   }
 }

--- a/src/main/scala/gwen/eval/EnvContext.scala
+++ b/src/main/scala/gwen/eval/EnvContext.scala
@@ -315,7 +315,7 @@ class EnvContext(options: GwenOptions, scopes: ScopedDataStack) extends LazyLogg
         }
         else v
     } getOrElse {
-      if (name.matches("""(data|top|left)(\.|\[).+""") || name == "top-left") {
+      if (name.matches("""(data|name|top\.name|left\.name)\[.+""") || name.matches("""(vertex\.name|record\.number)""")) {
         (featureScope.getObject("record") match {
           case Some(scope: ScopedData) => scope.getOpt(name)
           case _ =>

--- a/src/main/scala/gwen/eval/EnvContext.scala
+++ b/src/main/scala/gwen/eval/EnvContext.scala
@@ -315,24 +315,21 @@ class EnvContext(options: GwenOptions, scopes: ScopedDataStack) extends LazyLogg
         }
         else v
     } getOrElse {
-      if (name.matches("""(data|name|top\.name|left\.name)\[.+""") || name.matches("""(vertex\.name|record\.number)""")) {
-        (featureScope.getObject("record") match {
-          case Some(scope: ScopedData) => scope.getOpt(name)
-          case _ =>
-            featureScope.getObject("table") match {
+      (featureScope.getObject("record") match {
+        case Some(scope: ScopedData) => scope.getOpt(name)
+        case _ => featureScope.getObject("table") match {
             case Some(table: DataTable) => table.tableScope.getOpt(name)
-            case _ => unboundAttributeError(name)
+            case _ => None
           }
-        }).getOrElse(unboundAttributeError(name))
-      } else {
-        scopes.getOpt(name).getOrElse {
-          Settings.getOpt(name).getOrElse {
-            unboundAttributeError(name)
+      }).getOrElse {
+          scopes.getOpt(name).getOrElse {
+            Settings.getOpt(name).getOrElse {
+              unboundAttributeError(name)
+            }
           }
         }
       }
     }
-  }
 
   /**
     * Formats the given javascript expression in preparation for execute and return

--- a/src/main/scala/gwen/eval/EnvContext.scala
+++ b/src/main/scala/gwen/eval/EnvContext.scala
@@ -68,10 +68,10 @@ class EnvContext(options: GwenOptions, scopes: ScopedDataStack) extends LazyLogg
   
   /** Provides access to the global feature scope. */
   def featureScope: FeatureScope = scopes.featureScope
-  
-  /** Provides access to the local parameter scope. */
-  private[eval] val paramScope = scopes.paramScope
-  
+
+  /** Provides access to the local step scope. */
+  private[eval] val stepScope = scopes.stepScope
+
   /**
     * Closes any resources associated with the evaluation context. This implementation
     * does nothing (but subclasses can override).
@@ -262,7 +262,7 @@ class EnvContext(options: GwenOptions, scopes: ScopedDataStack) extends LazyLogg
     */
   def interpolate(step: Step): Step = 
     interpolate(step.expression) { name =>
-      Try(paramScope.get(name)).getOrElse(getBoundReferenceValue(name)) 
+      Try(stepScope.get(name)).getOrElse(getBoundReferenceValue(name))
     } match {
       case step.expression => step
       case expr =>
@@ -281,7 +281,7 @@ class EnvContext(options: GwenOptions, scopes: ScopedDataStack) extends LazyLogg
       case _ => Settings.getOpt(name) match {
         case Some(value) => value
         case _ =>
-          unboundAttributeError(name)
+          featureScope.objects.get("tableScope").flatMap(_.asInstanceOf[ScopedData].getOpt(name)).getOrElse(unboundAttributeError(name))
       }
     }
   }

--- a/src/main/scala/gwen/eval/EvalEngine.scala
+++ b/src/main/scala/gwen/eval/EvalEngine.scala
@@ -256,7 +256,7 @@ trait EvalEngine[T <: EnvContext] extends LazyLogging {
     * Repeats a step for each element in list of elements of type U.
     */
   def foreach[U](elements: ()=>Seq[U], element: String, step: Step, doStep: String, env: T) {
-    val steps = env.execute {
+    val steps =
       elements() match {
         case Nil =>
           logger.info(s"For-each[$element]: none found")
@@ -280,14 +280,6 @@ trait EvalEngine[T <: EnvContext] extends LazyLogging {
             }) :: acc
           } reverse
       }
-    } getOrElse {
-      env.featureScope.pushObject(element, "currentElement[DryRun]")
-      try {
-        List(evaluateStep(Step(step.keyword, doStep), env))
-      } finally {
-        env.featureScope.popObject(element)
-      }
-    }
     val foreachStepDef = new Scenario(List(Tag.StepDefTag, Tag.ForEachTag), element, Nil, None, steps, false, Nil, None)
     env.foreachStepDefs += (step.uniqueId -> foreachStepDef)
   }

--- a/src/main/scala/gwen/eval/EvalEngine.scala
+++ b/src/main/scala/gwen/eval/EvalEngine.scala
@@ -17,6 +17,7 @@
 package gwen.eval
 
 import com.typesafe.scalalogging.LazyLogging
+import gwen.GwenSettings
 import gwen.dsl._
 import gwen.Predefs._
 import gwen.errors._
@@ -138,7 +139,7 @@ trait EvalEngine[T <: EnvContext] extends LazyLogging {
           Step(iStep, failure, env.attachments)
         case Success(stepDefOpt) =>
           (stepDefOpt match {  
-            case Some((stepDef, _)) if env.paramScope.containsScope(stepDef.name) => None
+            case Some((stepDef, _)) if env.stepScope.containsScope(stepDef.name) => None
             case stepdef => stepdef 
           }) match {
             case None =>
@@ -192,7 +193,19 @@ trait EvalEngine[T <: EnvContext] extends LazyLogging {
   
   private def evalStepDef(stepDef: Scenario, step: Step, params: List[(String, String)], env: T): Step = {
     logger.debug(s"Evaluating ${stepDef.keyword}: ${stepDef.name}")
-    env.paramScope.push(stepDef.name, params)
+    env.stepScope.push(stepDef.name, params)
+    val dataTable = getDataTable(stepDef, step)
+    dataTable foreach { table =>
+      new ScopedData("dataTable") tap { tableScope =>
+        table.zipWithIndex foreach { case (nvps, idx) =>
+          nvps.foreach { case (name, value) =>
+            if (idx == 0) tableScope.set(s"data.$name", value)
+            tableScope.set(s"data[$idx].$name", value)
+          }
+        }
+        env.featureScope.objects.push("tableScope", tableScope)
+      }
+    }
     try {
       val steps = if (!stepDef.isOutline) evaluateSteps(stepDef.steps, env) else stepDef.steps
       val examples = if (stepDef.isOutline) evaluateExamples(stepDef.examples, env) else stepDef.examples
@@ -200,7 +213,28 @@ trait EvalEngine[T <: EnvContext] extends LazyLogging {
         logger.debug(s"${stepDef.keyword} evaluated: ${stepDef.name}")
       }
     } finally {
-      env.paramScope.pop
+      dataTable foreach { _ =>
+        env.featureScope.objects.pop("tableScope")
+      }
+      env.stepScope.pop
+    }
+  }
+
+  private def getDataTable(stepDef: Scenario, step: Step): Option[List[List[(String, String)]]] = {
+    stepDef.tags.find(_.name.startsWith("DataTable(")) map { tag =>
+      tag.name.trim match {
+        case r"""DataTable\(orientation="(horizontal|vertical)"$orientation,data="(.*?)"$namesCSV\)""" =>
+          step.table.map(_._2) match {
+            case Nil => dataTableError(s"Data table expected but not provided in step: '${step.toString}'")
+            case table =>
+              (if (orientation == "vertical") table.transpose else table) map { row =>
+                val names = namesCSV.split(",").toList
+                if (row.size != names.size) dataTableError(s"${row.size} names expected for $orientation data table but got ${names.size}: '${namesCSV}'")
+                names.zip(row)
+              }
+          }
+        case _ => syntaxError(s"""Invalid data table syntax: $tag - correct syntax is DataTable(orientation="horizontal|vertical",data="name1,name2..,nameN")""")
+      }
     }
   }
 
@@ -242,6 +276,46 @@ trait EvalEngine[T <: EnvContext] extends LazyLogging {
     step.expression match {
       case _ => undefinedStepError(step)
     }
+  }
+
+  /**
+    * Repeats a step for each element in list of elements of type U.
+    */
+  def foreach[U](elements: ()=>Seq[U], element: String, step: Step, doStep: String, env: T) {
+    val steps = env.execute {
+      elements() match {
+        case Nil =>
+          logger.info(s"For-each[$element]: none found")
+          Nil
+        case elems =>
+          val noOfElements = elems.size
+          logger.info(s"For-each[$element]: $noOfElements found")
+          elems.zipWithIndex.foldLeft(List[Step]()) { case (acc, (currentElement, index)) =>
+            env.featureScope.objects.push(element, currentElement)
+            (try {
+              EvalStatus(acc.map(_.evalStatus)) match {
+                case Failed(_, _) if env.execute(GwenSettings.`gwen.feature.failfast`).getOrElse(false) =>
+                  logger.info(s"Skipping [$element] ${index + 1} of $noOfElements")
+                  Step(step.pos, if (index == 0) StepKeyword.Given else StepKeyword.And, doStep, Skipped)
+                case _ =>
+                  logger.info(s"Processing [$element] ${index + 1} of $noOfElements")
+                  evaluateStep(Step(step.pos, if (index == 0) StepKeyword.Given else StepKeyword.And, doStep), env)
+              }
+            } finally {
+              env.featureScope.objects.pop(element)
+            }) :: acc
+          } reverse
+      }
+    } getOrElse {
+      env.featureScope.objects.push(element, "currentElement[DryRun]")
+      try {
+        List(evaluateStep(Step(step.keyword, doStep), env))
+      } finally {
+        env.featureScope.objects.pop(element)
+      }
+    }
+    val foreachStepDef = new Scenario(List(Tag.StepDefTag, Tag.ForEachTag), element, Nil, None, steps, false, Nil, None)
+    env.foreachStepDefs += (step.uniqueId -> foreachStepDef)
   }
   
   /**

--- a/src/main/scala/gwen/eval/FeatureScope.scala
+++ b/src/main/scala/gwen/eval/FeatureScope.scala
@@ -68,12 +68,12 @@ class ObjectCache {
   private var cache = Map[String, List[Any]]()
 
   /**
-    * Binds a named object to the internal cache.
+    * Pushes a named object to the internal cache.
     *
     * @param name the name to bind the object to
     * @param obj the object to bind
     */
-  def bind(name: String, obj: Any) {
+  def push(name: String, obj: Any) {
     cache.get(name) match {
       case Some(objs) => cache += (name -> (obj :: objs))
       case None => cache += (name -> List(obj))
@@ -93,7 +93,7 @@ class ObjectCache {
     *
     * @param name the name of the bound object to remove
     */
-  def clear[T](name: String) {
+  def pop[T](name: String) {
     cache.get(name) match {
       case Some(_::tail) if (tail.nonEmpty) => cache += (name -> tail)
       case _ => cache -= name

--- a/src/main/scala/gwen/eval/FeatureScope.scala
+++ b/src/main/scala/gwen/eval/FeatureScope.scala
@@ -33,9 +33,9 @@ class FeatureScope extends ScopedData("feature") {
     */
   private[eval] var currentScope: Option[ScopedData] = None
 
-  /** Map of cached objects. */
-  val objects = new ObjectCache()
-  
+  /** Map of object stacks. */
+  private var objectStack = Map[String, List[Any]]()
+
   /**
     * Binds a new attribute value to the scope.  If an attribute of the same
     * name already exists, then this new attribute overrides the existing one
@@ -59,48 +59,37 @@ class FeatureScope extends ScopedData("feature") {
       }
     }
 
-}
-
-/** Class for caching non string objects in a feature. */
-class ObjectCache {
-
-  /** Map of cached objects. */
-  private var cache = Map[String, List[Any]]()
-
   /**
-    * Pushes a named object to the internal cache.
+    * Pushes a named object to the object stack.
     *
     * @param name the name to bind the object to
-    * @param obj the object to bind
+    * @param obj the object to push
     */
-  def push(name: String, obj: Any) {
-    cache.get(name) match {
-      case Some(objs) => cache += (name -> (obj :: objs))
-      case None => cache += (name -> List(obj))
+  def pushObject(name: String, obj: Any) {
+    objectStack.get(name) match {
+      case Some(objs) => objectStack += (name -> (obj :: objs))
+      case None => objectStack += (name -> List(obj))
     }
   }
 
   /**
-    * Gets a bound object from the internal cache.
+    * Gets a bound object from the object stack.
     *
     * @param name the name of the bound object to get
     * @return Some(bound object) or None
     */
-  def get(name: String): Option[Any] = cache.get(name).flatMap(_.headOption)
+  def getObject(name: String): Option[Any] = objectStack.get(name).flatMap(_.headOption)
 
   /**
-    * Clears a bound object from the internal cache. Performs no operation if no object is not bound to the name.
+    * Clears a bound object from the object stack. Performs no operation if no object is not bound to the name.
     *
-    * @param name the name of the bound object to remove
+    * @param name the name of the bound object to pop
     */
-  def pop[T](name: String) {
-    cache.get(name) match {
-      case Some(_::tail) if (tail.nonEmpty) => cache += (name -> tail)
-      case _ => cache -= name
+  def popObject(name: String) {
+    objectStack.get(name) match {
+      case Some(_::tail) if (tail.nonEmpty) => objectStack += (name -> tail)
+      case _ => objectStack -= name
     }
   }
-
-  /** Resets the internal cache by creating a new one. */
-  private[eval] def reset() { cache = Map[String, List[Any]]() }
 
 }

--- a/src/main/scala/gwen/eval/LocalDataStack.scala
+++ b/src/main/scala/gwen/eval/LocalDataStack.scala
@@ -49,7 +49,7 @@ class LocalDataStack {
     * @param params the parameters to add
     * @return the newly added scope
     */
-  def push(scope: String, params: List[(String, String)]): ScopedData = { 
+  def push(scope: String, params: List[(String, String)]): ScopedData = {
     ScopedData(scope) tap { data =>
       params foreach { case (name, value) =>
         data.set(name, value)
@@ -66,12 +66,20 @@ class LocalDataStack {
     * Only the top of the stack is searched.
     *
     * @param name the name of the attribute to find
+    * @return the value if it is found (or throws error)
+    */
+  def get(name: String): String =
+    getOpt(name).getOrElse(unboundAttributeError(name, "local"))
+
+  /**
+    * Finds and retrieves an optional attribute bound in the local stack.
+    * Only the top of the stack is searched.
+    *
+    * @param name the name of the attribute to find
     * @return Some(value) if a value is found or None otherwise
     */
-  def get(name: String): String = 
-    (localData.headOption map (_.getOpt(name)) collectFirst { 
-      case Some(value) => value 
-    }).getOrElse(unboundAttributeError(name, "local"))
+  def getOpt(name: String): Option[String] =
+    localData.headOption.flatMap(_.getOpt(name)).headOption
     
   /**
     * Checks whether or not this local stack contains the 

--- a/src/main/scala/gwen/eval/ScopedDataStack.scala
+++ b/src/main/scala/gwen/eval/ScopedDataStack.scala
@@ -72,18 +72,18 @@ class ScopedDataStack() {
   private var scopes: mutable.ArrayStack[ScopedData] = _
   
   /** 
-    *  Provides access to the local StepDef scope (StepDef parameters
-    *  are pushed and poped in and out of this scope as StepDef calls
+    *  Provides access to the local step scope (StepDef parameters
+    *  and data tables are pushed and poped in and out of this scope as StepDef calls
     *  are made). 
     */
-  private[eval] val paramScope = new LocalDataStack()
+  private[eval] val stepScope = new LocalDataStack()
   
   reset()
   
   /** Resets the data stack. */
   def reset() {
       scopes = mutable.ArrayStack[ScopedData]() tap { _ push new FeatureScope() }
-      paramScope.reset()
+      stepScope.reset()
   }
   
   /**
@@ -273,9 +273,9 @@ class ScopedDataStack() {
     * @param name the name of the attribute to find
     * @return Some(value) if the attribute found or None otherwise
     */
-  def getInOpt(scope: String, name: String): Option[String] = 
-    scopes.toIterator filter(_.scope == scope) map (_.getOpt(name)) collectFirst { 
-      case Some(value) => value 
+  def getInOpt(scope: String, name: String): Option[String] =
+    scopes.toIterator filter(_.scope == scope) map (_.getOpt(name)) collectFirst {
+      case Some(value) => value
     } match {
       case None if scope != featureScope.scope =>
         getInOpt(featureScope.scope, name)

--- a/src/main/scala/gwen/eval/support/DefaultEngineSupport.scala
+++ b/src/main/scala/gwen/eval/support/DefaultEngineSupport.scala
@@ -20,13 +20,13 @@ import scala.sys.process.stringSeqToProcess
 import scala.sys.process.stringToProcess
 import gwen.Predefs.RegexContext
 import gwen.dsl.Step
-import gwen.eval.EnvContext
+import gwen.eval.{EnvContext, EvalEngine}
 import gwen.errors._
 import gwen.Settings
 import gwen.Predefs.Kestrel
 
 /** Provides the common default steps that all engines can support. */
-trait DefaultEngineSupport[T <: EnvContext] {
+trait DefaultEngineSupport[T <: EnvContext] extends EvalEngine[T] {
 
   /**
     * Defines the default steps supported by all engines.
@@ -36,7 +36,7 @@ trait DefaultEngineSupport[T <: EnvContext] {
     * @throws gwen.errors.UndefinedStepException if the given step is undefined
     *         or unsupported
     */
-  def evaluate(step: Step, env: T): Unit = {
+  override def evaluate(step: Step, env: T): Unit = {
     step.expression match {
 
       case r"""my (.+?)$name (?:property|setting) (?:is|will be) "(.*?)"$$$value""" =>
@@ -152,6 +152,11 @@ trait DefaultEngineSupport[T <: EnvContext] {
       case r"""(.+?)$attribute should be absent""" => env.execute {
         assert(env.activeScope.getOpt(attribute).isEmpty, s"Expected $attribute to be absent")
       }
+
+      case r"""(.+?)$doStep for each data table record""" =>
+
+        //val binding = env.getLocatorBinding(iteration)
+        //foreach(() => env.locateAll(env, binding), element, step, doStep, env)
       
       case _ => undefinedStepError(step)
       

--- a/src/main/scala/gwen/eval/support/DefaultEngineSupport.scala
+++ b/src/main/scala/gwen/eval/support/DefaultEngineSupport.scala
@@ -19,11 +19,13 @@ package gwen.eval.support
 import scala.sys.process.stringSeqToProcess
 import scala.sys.process.stringToProcess
 import gwen.Predefs.RegexContext
-import gwen.dsl.Step
-import gwen.eval.{EnvContext, EvalEngine}
+import gwen.dsl.{FlatTable, Step}
+import gwen.eval.{EnvContext, EvalEngine, ScopedData}
 import gwen.errors._
 import gwen.Settings
 import gwen.Predefs.Kestrel
+
+import scala.util.Try
 
 /** Provides the common default steps that all engines can support. */
 trait DefaultEngineSupport[T <: EnvContext] extends EvalEngine[T] {
@@ -141,6 +143,17 @@ trait DefaultEngineSupport[T <: EnvContext] extends EvalEngine[T] {
           assert(result, s"Expected $source at $matcher '$path' to ${if(negate) "not " else ""}$operator '$expression' but got '$actual'")
         }
 
+      case r"""(.+?)$doStep for each data record""" =>
+        val dataTable = env.featureScope.getObject("table") match {
+          case Some(table: FlatTable) => table
+          case Some(other) => dataTableError(s"Cannot use for each on object of type: ${other.getClass.getName}")
+          case _ => dataTableError("Calling step has no data table")
+        }
+        val records = () => {
+          dataTable.records.indices.map(idx => dataTable.recordScope(idx))
+        }
+        foreach(records, "record", step, doStep, env)
+
       case r"""(.+?)$attribute should( not)?$negation (be|contain|start with|end with|match regex|match xpath|match json path)$operator "(.*?)"$$$expression""" =>
         val actualValue = env.getBoundReferenceValue(attribute)
         env.execute {
@@ -150,13 +163,8 @@ trait DefaultEngineSupport[T <: EnvContext] extends EvalEngine[T] {
         }
 
       case r"""(.+?)$attribute should be absent""" => env.execute {
-        assert(env.activeScope.getOpt(attribute).isEmpty, s"Expected $attribute to be absent")
+        assert(Try(env.getBoundReferenceValue(attribute)).isFailure, s"Expected $attribute to be absent")
       }
-
-      case r"""(.+?)$doStep for each data table record""" =>
-
-        //val binding = env.getLocatorBinding(iteration)
-        //foreach(() => env.locateAll(env, binding), element, step, doStep, env)
       
       case _ => undefinedStepError(step)
       

--- a/src/main/scala/gwen/eval/support/InterpolationSupport.scala
+++ b/src/main/scala/gwen/eval/support/InterpolationSupport.scala
@@ -26,12 +26,12 @@ trait InterpolationSupport extends LazyLogging {
 
   private val propertySyntax = """^(?s)(.*)\$\{(.+?)\}(.*)$""".r
   private val paramSyntax = """^(?s)(.*)\$<(.+?)>(.*)$""".r
-  
-  @tailrec
+
   final def interpolate(source: String)(resolve: String => String): String = source match {
       case propertySyntax(prefix, property, suffix) =>
         logger.debug(s"Resolving property-syntax binding: $${$property}")
-        interpolate(s"$prefix${resolve(property)}$suffix") { resolve }
+        val iProperty = interpolate(property) { resolve }
+        interpolate(s"$prefix${resolve(iProperty)}$suffix") { resolve }
       case paramSyntax(prefix, param, suffix) =>
         logger.debug(s"Resolving param-syntax binding: $$<$param>")
         val resolved = resolve(s"<${param}>")

--- a/src/test/scala/gwen/dsl/DataTableTest.scala
+++ b/src/test/scala/gwen/dsl/DataTableTest.scala
@@ -1,0 +1,462 @@
+/*
+ * Copyright 2017 Branko Juric, Brady Wood
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gwen.dsl
+
+import org.scalatest.{FlatSpec, Matchers}
+import gwen.dsl.Tag.string2Tag
+import gwen.errors.DataTableException
+
+/**
+  * Data table tests.
+  */
+class DataTableTest extends FlatSpec with Matchers with GherkinParser {
+
+  private val parse = parseStep(_: String).get
+  
+  "Data in multi record horizontal table with no header" should "be accessible" in {
+
+    val dataTable = DataTable(
+      """@DataTable(horizontal="a,b,c")""", parse(
+      """
+        |Given a multi record horizontal table with no header
+        |      | 0 | 1 | 1 |
+        |      | 1 | 1 | 2 |
+        |      | 1 | 2 | 3 |
+        |      | 2 | 3 | 5 |
+        |      | 3 | 5 | 8 |
+      """.stripMargin)).asInstanceOf[FlatTable]
+
+    checkFlatTable_multiRecord(dataTable)
+
+  }
+
+  "Data in multi record horizontal table with a top header" should "be accessible" in {
+
+    val dataTable = DataTable(
+      """@DataTable(header="top")""", parse(
+      """
+        |Given a multi record horizontal table with a top header
+        |      | a | b | c |
+        |      | 0 | 1 | 1 |
+        |      | 1 | 1 | 2 |
+        |      | 1 | 2 | 3 |
+        |      | 2 | 3 | 5 |
+        |      | 3 | 5 | 8 |
+      """.stripMargin)).asInstanceOf[FlatTable]
+
+    checkFlatTable_multiRecord(dataTable)
+
+  }
+
+  "Data in multi record vertical table with no header" should "be accessible" in {
+
+    val dataTable = DataTable(
+      """@DataTable(vertical="a,b,c")""", parse(
+      """
+        |Given a multi record vertical table with no header
+        |      | 0 | 1 | 1 | 2 | 3 |
+        |      | 1 | 1 | 2 | 3 | 5 |
+        |      | 1 | 2 | 3 | 5 | 8 |
+      """.stripMargin)).asInstanceOf[FlatTable]
+
+    checkFlatTable_multiRecord(dataTable)
+
+  }
+
+  "Data in multi record vertical table with a left header" should "be accessible" in {
+
+    val dataTable = DataTable(
+      """@DataTable(header="left")""", parse(
+      """
+        |Given a multi record horizontal table with a left header
+        |      | a | 0 | 1 | 1 | 2 | 3 |
+        |      | b | 1 | 1 | 2 | 3 | 5 |
+        |      | c | 1 | 2 | 3 | 5 | 8 |
+      """.stripMargin)).asInstanceOf[FlatTable]
+
+    checkFlatTable_multiRecord(dataTable)
+
+  }
+
+  def checkFlatTable_multiRecord(dataTable: FlatTable) {
+
+    dataTable.records.size should be (5)
+    dataTable.records.head.size should be (3)
+
+    val table = dataTable.tableScope
+    table.get("name[1]") should be ("a")
+    table.get("name[2]") should be ("b")
+    table.get("name[3]") should be ("c")
+    table.get("data[a]") should be ("0")
+    table.get("data[b]") should be ("1")
+    table.get("data[c]") should be ("1")
+    table.get("data[1][a]") should be ("0")
+    table.get("data[1][b]") should be ("1")
+    table.get("data[1][c]") should be ("1")
+    table.get("data[2][a]") should be ("1")
+    table.get("data[2][b]") should be ("1")
+    table.get("data[2][c]") should be ("2")
+    table.get("data[3][a]") should be ("1")
+    table.get("data[3][b]") should be ("2")
+    table.get("data[3][c]") should be ("3")
+    table.get("data[4][a]") should be ("2")
+    table.get("data[4][b]") should be ("3")
+    table.get("data[4][c]") should be ("5")
+    table.get("data[5][a]") should be ("3")
+    table.get("data[5][b]") should be ("5")
+    table.get("data[5][c]") should be ("8")
+    table.findEntries(_ => true).size should be (21)
+
+    dataTable.records.indices foreach { recIndex =>
+      val recNo = recIndex + 1
+      val record = dataTable.recordScope(recIndex)
+      record.get("record.number") should be (s"$recNo")
+      record.get("name[1]") should be (table.get("name[1]"))
+      record.get("name[2]") should be (table.get("name[2]"))
+      record.get("name[3]") should be (table.get("name[3]"))
+      record.get("data[a]") should be (table.get(s"data[$recNo][a]"))
+      record.get("data[b]") should be (table.get(s"data[$recNo][b]"))
+      record.get("data[c]") should be (table.get(s"data[$recNo][c]"))
+      record.findEntries(_ => true).size should be (7)
+    }
+
+  }
+
+  "Data in single record horizontal table with no header" should "be accessible" in {
+
+    val dataTable = DataTable(
+      """@DataTable(horizontal="a,b,c")""", parse(
+      """
+        |Given a single record horizontal table with no header
+        |      | 1 | 2 | 3 |
+      """.stripMargin)).asInstanceOf[FlatTable]
+
+    checkFlatTable_singleRecord(dataTable)
+
+  }
+
+  "Data in single record horizontal table with a top header" should "be accessible" in {
+
+    val dataTable = DataTable(
+      """@DataTable(header="top")""", parse(
+      """
+        |Given a single record horizontal table with a top header
+        |      | a | b | c |
+        |      | 1 | 2 | 3 |
+      """.stripMargin)).asInstanceOf[FlatTable]
+
+    checkFlatTable_singleRecord(dataTable)
+
+  }
+
+  "Data in single record vertical table with no header" should "be accessible" in {
+
+    val dataTable = DataTable(
+      """@DataTable(vertical="a,b,c")""", parse(
+      """
+        |Given a single record vertical table with no header
+        |      | 1 |
+        |      | 2 |
+        |      | 3 |
+      """.stripMargin)).asInstanceOf[FlatTable]
+
+    checkFlatTable_singleRecord(dataTable)
+
+  }
+
+  "Data in single record vertical table with a left header" should "be accessible" in {
+
+    val dataTable = DataTable(
+      """@DataTable(header="left")""", parse(
+      """
+        |Given a single record vertical table with a left header
+        |      | a | 1 |
+        |      | b | 2 |
+        |      | c | 3 |
+      """.stripMargin)).asInstanceOf[FlatTable]
+
+    checkFlatTable_singleRecord(dataTable)
+
+  }
+
+  def checkFlatTable_singleRecord(dataTable: FlatTable) {
+
+    dataTable.records.size should be (1)
+    dataTable.records.head.size should be (3)
+
+    val table = dataTable.tableScope
+    table.get("name[1]") should be ("a")
+    table.get("name[2]") should be ("b")
+    table.get("name[3]") should be ("c")
+    table.get("data[a]") should be ("1")
+    table.get("data[b]") should be ("2")
+    table.get("data[c]") should be ("3")
+    table.get("data[1][a]") should be ("1")
+    table.get("data[1][b]") should be ("2")
+    table.get("data[1][c]") should be ("3")
+    table.findEntries(_ => true).size should be (9)
+
+    dataTable.records.indices foreach { recIndex =>
+      val recNo = recIndex + 1
+      val record = dataTable.recordScope(recIndex)
+      record.get("record.number") should be (s"$recNo")
+      record.get("name[1]") should be (table.get("name[1]"))
+      record.get("name[2]") should be (table.get("name[2]"))
+      record.get("name[3]") should be (table.get("name[3]"))
+      record.get("data[a]") should be (table.get(s"data[$recNo][a]"))
+      record.get("data[b]") should be (table.get(s"data[$recNo][b]"))
+      record.get("data[c]") should be (table.get(s"data[$recNo][c]"))
+      record.findEntries(_ => true).size should be (7)
+    }
+
+  }
+
+  "Data in single item horizontal table with no header" should "be accessible" in {
+
+    val dataTable = DataTable(
+      """@DataTable(horizontal="a")""", parse(
+      """
+        |Given a single item horizontal table with no header
+        |      | 1 |
+      """.stripMargin)).asInstanceOf[FlatTable]
+
+    checkFlatTable_singleItem(dataTable)
+
+  }
+
+  "Data in single item horizontal table with top header" should "be accessible" in {
+
+    val dataTable = DataTable(
+      """@DataTable(header="top")""", parse(
+      """
+        |Given a single item horizontal table with a top header
+        |      | a |
+        |      | 1 |
+      """.stripMargin)).asInstanceOf[FlatTable]
+
+    checkFlatTable_singleItem(dataTable)
+
+  }
+
+  "Data in single item vertical table with no header" should "be accessible" in {
+
+    val dataTable = DataTable(
+      """@DataTable(vertical="a")""", parse(
+      """
+        |Given a single item vertical table with no header
+        |      | 1 |
+      """.stripMargin)).asInstanceOf[FlatTable]
+
+    checkFlatTable_singleItem(dataTable)
+
+  }
+
+
+  "Data in single item vertical table with left header" should "be accessible" in {
+
+    val dataTable = DataTable(
+      """@DataTable(header="left")""", parse(
+      """
+        |Given a single item vertical table with a left header
+        |      | a | 1 |
+      """.stripMargin)).asInstanceOf[FlatTable]
+
+    checkFlatTable_singleItem(dataTable)
+
+  }
+
+  def checkFlatTable_singleItem(dataTable: FlatTable) {
+
+    dataTable.records.size should be (1)
+    dataTable.records.head.size should be (1)
+
+    val table = dataTable.tableScope
+    table.get("name[1]") should be ("a")
+    table.get("data[a]") should be ("1")
+    table.get("data[1][a]") should be ("1")
+    table.findEntries(_ => true).size should be (3)
+
+    dataTable.records.indices foreach { recIndex =>
+      val recNo = recIndex + 1
+      val record = dataTable.recordScope(recIndex)
+      record.get("record.number") should be (s"$recNo")
+      record.get("name[1]") should be (table.get("name[1]"))
+      record.get("data[a]") should be (table.get("data[1][a]"))
+      record.findEntries(_ => true).size should be (3)
+    }
+
+  }
+
+  "Zero item horizontal table with top header" should "error" in {
+
+    intercept[DataTableException] {
+      DataTable(
+        """@DataTable(header="top")""", parse(
+        """
+          |Given a zero item horizontal table with a top header
+          |      |  a  |
+        """.stripMargin)).asInstanceOf[MatrixTable]
+    }
+
+  }
+
+  "Zero item vertical table with left header" should "error" in {
+
+    intercept[DataTableException] {
+      DataTable(
+        """@DataTable(header="left")""", parse(
+        """
+          |Given a zero item vertical table with a left header
+          |      |  a  |
+        """.stripMargin)).asInstanceOf[MatrixTable]
+    }
+
+  }
+
+  "Data in multi record matrix table" should "be accessible" in {
+
+    val dataTable = DataTable(
+      """@DataTable(type="matrix")""", parse(
+      """
+        |Given a multi record matrix table
+        |      |  x  | uno | due | tre |
+        |      | uno |  1  |  2  |  3  |
+        |      | due |  2  |  4  |  6  |
+        |      | tre |  3  |  6  |  9  |
+      """.stripMargin)).asInstanceOf[MatrixTable]
+
+    dataTable.records.size should be (3)
+    dataTable.records.head.size should be (3)
+
+    val table = dataTable.tableScope
+    table.get("vertex.name") should be ("x")
+    table.get("top.name[1]") should be ("uno")
+    table.get("top.name[2]") should be ("due")
+    table.get("top.name[3]") should be ("tre")
+    table.get("left.name[1]") should be ("uno")
+    table.get("left.name[2]") should be ("due")
+    table.get("left.name[3]") should be ("tre")
+    table.get("data[uno][uno]") should be ("1")
+    table.get("data[uno][due]") should be ("2")
+    table.get("data[uno][tre]") should be ("3")
+    table.get("data[due][uno]") should be ("2")
+    table.get("data[due][due]") should be ("4")
+    table.get("data[due][tre]") should be ("6")
+    table.get("data[tre][uno]") should be ("3")
+    table.get("data[tre][due]") should be ("6")
+    table.get("data[tre][tre]") should be ("9")
+    table.findEntries(_ => true).size should be (16)
+
+  }
+
+  "Data in single record horizontal matrix table" should "be accessible" in {
+
+    val dataTable = DataTable(
+      """@DataTable(type="matrix")""", parse(
+      """
+        |Given a single record horizontal matrix table
+        |      |  x  | uno | due | tre |
+        |      | uno |  1  |  2  |  3  |
+      """.stripMargin)).asInstanceOf[MatrixTable]
+
+    dataTable.records.size should be (1)
+    dataTable.records.head.size should be (3)
+
+    val table = dataTable.tableScope
+    table.get("vertex.name") should be ("x")
+    table.get("top.name[1]") should be ("uno")
+    table.get("top.name[2]") should be ("due")
+    table.get("top.name[3]") should be ("tre")
+    table.get("left.name[1]") should be ("uno")
+    table.get("data[uno][uno]") should be ("1")
+    table.get("data[due][uno]") should be ("2")
+    table.get("data[tre][uno]") should be ("3")
+    table.findEntries(_ => true).size should be (8)
+
+  }
+
+  "Data in single record vertical matrix table" should "be accessible" in {
+
+    val dataTable = DataTable(
+      """@DataTable(type="matrix")""", parse(
+      """
+        |Given a single record vertical matrix table
+        |      |  x  | uno |
+        |      | uno |  1  |
+        |      | due |  2  |
+        |      | tre |  3  |
+      """.stripMargin)).asInstanceOf[MatrixTable]
+
+    dataTable.records.size should be (3)
+    dataTable.records.head.size should be (1)
+
+    val table = dataTable.tableScope
+    table.get("vertex.name") should be ("x")
+    table.get("top.name[1]") should be ("uno")
+    table.get("left.name[1]") should be ("uno")
+    table.get("left.name[2]") should be ("due")
+    table.get("left.name[3]") should be ("tre")
+    table.get("data[uno][uno]") should be ("1")
+    table.get("data[uno][due]") should be ("2")
+    table.get("data[uno][tre]") should be ("3")
+    table.findEntries(_ => true).size should be (8)
+
+  }
+
+  "Data in single item matrix table" should "be accessible" in {
+
+    val dataTable = DataTable(
+      """@DataTable(type="matrix")""", parse(
+      """
+        |Given a single item matrix table
+        |      |  x  | uno |
+        |      | uno |  1  |
+      """.stripMargin)).asInstanceOf[MatrixTable]
+
+    dataTable.records.size should be (1)
+    dataTable.records.head.size should be (1)
+
+    val table = dataTable.tableScope
+    table.get("vertex.name") should be ("x")
+    table.get("top.name[1]") should be ("uno")
+    table.get("left.name[1]") should be ("uno")
+    table.get("data[uno][uno]") should be ("1")
+    table.findEntries(_ => true).size should be (4)
+
+  }
+
+  "Zero item matrix table" should "error" in {
+
+    intercept[DataTableException] {
+      DataTable(
+        """@DataTable(type="matrix")""", parse(
+        """
+          |Given a single item matrix table
+          |      |  x  |
+        """.stripMargin)).asInstanceOf[MatrixTable]
+    }
+
+  }
+
+  "Zero table" should "error" in {
+
+    intercept[DataTableException] {
+      DataTable("""@DataTable(horizontal="none")""", parse("Given no table")).asInstanceOf[MatrixTable]
+    }
+
+  }
+
+}

--- a/src/test/scala/gwen/dsl/PrettyPrintParserTest.scala
+++ b/src/test/scala/gwen/dsl/PrettyPrintParserTest.scala
@@ -68,7 +68,14 @@ class PrettyPrintParserTest extends FlatSpec with Matchers with SpecNormaliser w
               follow contain the data that is bound to each scenario that is evaluated.
               | string 1 | string 2 | result   |
               | howdy    | doo      | howdydoo |
-              | any      | thing    | anything |"""
+              | any      | thing    | anything |
+
+    Scenario: Numbers as words
+        Given a mapping of words to numbers
+         Then the word should match the number
+         | one   | 1 |
+         | two   | 2 |
+         | three | 3 |"""
  
   "parsing pretty printed Gwen feature" should "yield same AST" in {
     
@@ -149,16 +156,22 @@ Background: The butterfly effect
   Examples: Basic string concatenation
             The header row contains the placeholder names. The body rows that
             follow contain the data that is bound to each scenario that is evaluated.
-            | string 1 | string 2 | result |
-            | howdy | doo | howdydoo |
-            | any | thing | anything |""".replace("\r", ""))
+            | string 1 | string 2 | result   |
+            | howdy    | doo      | howdydoo |
+            | any      | thing    | anything |
+
+  Scenario: Numbers as words
+      Given a mapping of words to numbers
+       Then the word should match the number
+            | one   | 1 |
+            | two   | 2 |
+            | three | 3 |""".replace("\r", ""))
     
   }
 
   "pretty print of normalised Gwen feature" should "replicate background for each expanded scenario" in {
 
     val specFeature = normalise(parse(featureString).get, None, None)
-    println(prettyPrint(specFeature))
     prettyPrint(specFeature).replace("\r", "") should be ("""   @wip
    Feature: Gwen
             As a tester
@@ -216,7 +229,20 @@ Background: The butterfly effect
       Given string 1 is "any"
         And string 2 is "thing"
        When I join the two strings
-       Then the result should be "anything"""".replace("\r", ""))
+       Then the result should be "anything"
+
+Background: The butterfly effect
+            Sensitivity to initial conditions
+      Given a deterministic nonlinear system
+       When a small change is initially applied
+       Then a large change will eventually result
+
+  Scenario: Numbers as words
+      Given a mapping of words to numbers
+       Then the word should match the number
+            | one   | 1 |
+            | two   | 2 |
+            | three | 3 |""".replace("\r", ""))
 
   }
     

--- a/src/test/scala/gwen/eval/EnvContextTest.scala
+++ b/src/test/scala/gwen/eval/EnvContextTest.scala
@@ -373,18 +373,18 @@ class EnvContextTest extends FlatSpec with Matchers {
 
     val env = newEnv
     env.featureScope.pushObject("table", table1)
-    env.getBoundReferenceValue("data.token") should be ("1")
+    env.getBoundReferenceValue("data[token]") should be ("1")
     env.featureScope.pushObject("table", table2)
-    env.getBoundReferenceValue("data.token") should be ("2")
-    env.featureScope.pushObject("record", new ScopedData("record").set("data.token", "0"))
-    env.getBoundReferenceValue("data.token") should be ("0")
+    env.getBoundReferenceValue("data[token]") should be ("2")
+    env.featureScope.pushObject("record", new ScopedData("record").set("data[token]", "0"))
+    env.getBoundReferenceValue("data[token]") should be ("0")
     env.featureScope.popObject("record")
-    env.getBoundReferenceValue("data.token") should be ("2")
+    env.getBoundReferenceValue("data[token]") should be ("2")
     env.featureScope.popObject("table")
-    env.getBoundReferenceValue("data.token") should be ("1")
+    env.getBoundReferenceValue("data[token]") should be ("1")
     env.featureScope.popObject("table")
     intercept[UnboundAttributeException] {
-      env.getBoundReferenceValue("data.token")
+      env.getBoundReferenceValue("data[token]")
     }
   }
   

--- a/src/test/scala/gwen/eval/EvalEngineTest.scala
+++ b/src/test/scala/gwen/eval/EvalEngineTest.scala
@@ -23,11 +23,8 @@ import gwen.errors.UndefinedStepException
 import gwen.eval.support.DefaultEngineSupport
 
 class TestEnvContext(val options: GwenOptions, val scopes: ScopedDataStack) extends EnvContext(options, scopes)
-class TestEvalEngine extends EvalEngine[TestEnvContext] with DefaultEngineSupport[TestEnvContext] {
+class TestEvalEngine extends DefaultEngineSupport[TestEnvContext] {
   override def init(options: GwenOptions, scopes: ScopedDataStack): TestEnvContext = new TestEnvContext(options, scopes)
-  override def evaluate(step: Step, env: TestEnvContext) {
-    super.evaluate(step, env)
-  }
 }
   
 class EvalEngineTest extends FlatSpec with Matchers {

--- a/src/test/scala/gwen/eval/GwenInterpreterTest.scala
+++ b/src/test/scala/gwen/eval/GwenInterpreterTest.scala
@@ -103,14 +103,14 @@ class GwenInterpreterTest extends FlatSpec with Matchers with MockitoSugar {
     when(mockEnv.attachments).thenReturn(Nil)
     when(mockEnv.interpolate(step1)).thenReturn(step1)
     when(mockEnv.interpolate(step2)).thenReturn(step2)
-    when(mockEnv.paramScope).thenReturn(paramScope)
+    when(mockEnv.stepScope).thenReturn(paramScope)
     val result = interpreter(mockEnv).interpretStep("Given I am a valid stepdef", mockEnv)
     result match {
       case TrySuccess(step) =>
         step.keyword should be (StepKeyword.Given)
         step.expression should be ("I am a valid stepdef")
         step.evalStatus.status should be (StatusKeyword.Passed)
-      case TryFailure(err) => 
+      case TryFailure(err) =>
         fail(s"success expected but got $err")
     }
   }
@@ -200,7 +200,7 @@ class GwenInterpreterTest extends FlatSpec with Matchers with MockitoSugar {
     when(mockEnv.getStepDef("a large change will eventually result")).thenReturn(None)
     when(mockEnv.getStepDef("")).thenReturn(None)
     when(mockEnv.attachments).thenReturn(Nil)
-    when(mockEnv.paramScope).thenReturn(paramScope)
+    when(mockEnv.stepScope).thenReturn(paramScope)
     when(mockEnv.loadedMeta).thenReturn(Nil)
     val step1 = Step(StepKeyword.Given, "I am an observer")
     val step2 = Step(StepKeyword.Given, "the butterfly flaps its wings")

--- a/src/test/scala/gwen/eval/support/InterpolationSupportTest.scala
+++ b/src/test/scala/gwen/eval/support/InterpolationSupportTest.scala
@@ -49,7 +49,7 @@ class InterpolationSupportTest extends FlatSpec with Matchers with Interpolation
     } should be ("""Hey you good thing!""")
   }
   
-  """interpolate adjecent values using property syntax: ${property-0} ${property-1}"""" should "resolve" in {
+  """interpolate adjacent values using property syntax: ${property-0} ${property-1}"""" should "resolve" in {
     interpolate("""Hey you ${property-0} ${property-1} thing!""") {
       case "id" => "0"
       case "property-0" => "really"
@@ -58,7 +58,7 @@ class InterpolationSupportTest extends FlatSpec with Matchers with Interpolation
     } should be ("""Hey you really good thing!""")
   }
   
-  """interpolate adjecent values using property syntax (no space): ${property-0}${property-1}"""" should "resolve" in {
+  """interpolate adjacent values using property syntax (no space): ${property-0}${property-1}"""" should "resolve" in {
     interpolate("""Hey you ${property-0}${property-1} thing!""") {
       case "id" => "0"
       case "property-0" => "go"
@@ -141,5 +141,21 @@ class InterpolationSupportTest extends FlatSpec with Matchers with Interpolation
       """hello
         |you""".stripMargin
     interpolate(source) { _ => "you" } should be(target)
+  }
+
+  """Nested parameter in property: ${property-$<param>}"""" should "resolve" in {
+    interpolate("""Hey you ${property-$<id>} thing!""") {
+      case "<id>" => "0"
+      case "property-0" => "good"
+      case x => s"undefined($x)"
+    } should be ("""Hey you good thing!""")
+  }
+
+  """Nested property in parameter: $<property-${param}>"""" should "resolve" in {
+    interpolate("""Hey you $<property-${id}> thing!""") {
+      case "id" => "0"
+      case "<property-0>" => "good"
+      case x => s"undefined($x)"
+    } should be ("""Hey you good thing!""")
   }
 }

--- a/src/test/scala/gwen/sample/tables/TablesInterpreterTest.scala
+++ b/src/test/scala/gwen/sample/tables/TablesInterpreterTest.scala
@@ -1,19 +1,19 @@
 /*
- * Copyright 2016-2017 Branko Juric, Brady Wood
- * 
+ * Copyright 2017 Branko Juric, Brady Wood
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package gwen.sample.bindings
+package gwen.sample.tables
 
 import gwen.dsl.Failed
 import gwen.dsl.Passed
@@ -29,35 +29,34 @@ import gwen.eval.GwenInterpreter
 import gwen.eval.GwenApp
 import gwen.eval.support.DefaultEngineSupport
 
-class BindingsEnvContext(val options: GwenOptions, val scopes: ScopedDataStack) 
+class TablesEnvContext(val options: GwenOptions, val scopes: ScopedDataStack)
   extends EnvContext(options, scopes) {
   override def dsl: List[String] = Nil
 }
 
-trait BindingsEvalEngine extends DefaultEngineSupport[BindingsEnvContext] {
-  override def init(options: GwenOptions, scopes: ScopedDataStack): BindingsEnvContext = new BindingsEnvContext(options, scopes)
+trait TablesEvalEngine extends DefaultEngineSupport[TablesEnvContext] {
+  override def init(options: GwenOptions, scopes: ScopedDataStack): TablesEnvContext = new TablesEnvContext(options, scopes)
 }
 
-class BindingsInterpreter 
-  extends GwenInterpreter[BindingsEnvContext]
-  with BindingsEvalEngine
+class TablesInterpreter
+  extends GwenInterpreter[TablesEnvContext]
+  with TablesEvalEngine
 
-object BindingsInterpreter 
-  extends GwenApp(new BindingsInterpreter)
+object TablesInterpreter
+  extends GwenApp(new TablesInterpreter)
 
-class BindingsInterpreterTest extends FlatSpec {
+class TablesInterpreterTest extends FlatSpec {
   
-  "binding features" should "evaluate without error" in {
+  "Data tables" should "evaluate without error" in {
     
     val options = GwenOptions(
       batch = true,
-      reportDir = Some(new File("target/report/bindings")), 
+      reportDir = Some(new File("target/report/tables")),
       reportFormats = List(ReportFormat.html, ReportFormat.junit, ReportFormat.json),
-      features = List(new File("features/sample/bindings")),
-      properties = List(new File("src/test/resources/gwen/bindings/bindings.properties"))
+      features = List(new File("features/sample/tables"))
     )
       
-    val launcher = new GwenLauncher(new BindingsInterpreter())
+    val launcher = new GwenLauncher(new TablesInterpreter())
     launcher.run(options, None) match {
       case Passed(_) => // excellent :)
       case Failed(_, error) => error.printStackTrace(); fail(error.getMessage)
@@ -65,18 +64,17 @@ class BindingsInterpreterTest extends FlatSpec {
     }
   }
   
-  "binding features" should "pass --dry-run test" in {
+  "Data tables" should "pass --dry-run test" in {
     
     val options = GwenOptions(
       batch = true,
-      reportDir = Some(new File("target/report/bindings-dry-run")), 
+      reportDir = Some(new File("target/report/tables-dry-run")),
       reportFormats = List(ReportFormat.html, ReportFormat.junit, ReportFormat.json),
-      features = List(new File("features/sample/bindings")),
-      dryRun = true,
-      properties = List(new File("src/test/resources/gwen/bindings/bindings.properties"))
+      features = List(new File("features/sample/tables")),
+      dryRun = true
     )
       
-    val launcher = new GwenLauncher(new BindingsInterpreter())
+    val launcher = new GwenLauncher(new TablesInterpreter())
     launcher.run(options, None) match {
       case Passed(_) => // excellent :)
       case Failed(_, error) => error.printStackTrace(); fail(error.getMessage)

--- a/version.sbt
+++ b/version.sbt
@@ -1,6 +1,6 @@
 enablePlugins(GitVersioning)
 
-git.baseVersion := "2.6.1"
+git.baseVersion := "2.7.0"
 
 git.useGitDescribe := true
 


### PR DESCRIPTION
# Data Tables for Gwen
This PR adds support for Gherkin data tables to steps in Gwen. If a step contains a data table, then a `@StepDef` scenario must be declared for it and be annotated with a `@DataTable` tag to make the contained data accessible as shown in the examples below.

# Horizontal Data Tables

## With header

This example has 3 rows and 3 columns of data and a top header. The first horizontal row is the header and the rows that follow are data records.

### In feature..
```gherkin
   Scenario: Horizontal table with header
       Given each row contains a number and its square and cube
             | number | square | cube |
             | 1      | 1      | 1    |
             | 2      | 4      | 8    |
             | 3      | 9      | 27   |
```

### In meta..
We specify the `@DataTable` tag on the StepDef with the `header` attribute set to `top` to assign the names in the top header record to the elements in each data record. We then reference the data using `data[name]` to access the 1st record (or the current record in a 'for each' step), or `data[recordNo][name]` to access any explicit record (where `recordNo` of 1st record is 1, 2nd is 2, and so on).
```gherkin
  @StepDef
  @DataTable(header="top")
  Scenario: each row contains a number and its square and cube
      Given name[1] should be "number"
        And name[2] should be "square"
        And name[3] should be "cube"
        And data[number] should be "1"
        And data[1][number] should be "1"
        And data[2][number] should be "2"
        And data[3][number] should be "3"
        And data[square] should be "1"
        And data[1][square] should be "1"
        And data[2][square] should be "4"
        And data[3][square] should be "9"
        And data[cube] should be "1"
        And data[1][cube] should be "1"
        And data[2][cube] should be "8"
        And data[3][cube] should be "27"
        And number ^ 2 = square of number for each data record
        And number ^ 3 = cube of number for each data record

  @StepDef
  Scenario: number ^ <power> = <function> of number
      Given the result is defined by javascript "Math.pow(${data[number]}, $<power>)"
       Then the result should be "${data[$<function>]}.0"
```

## Without header

This example has 3 rows and 2 columns of data and no header. Each horizontal row is a data record.

### In feature..
```gherkin
   Scenario: Horizontal data table with no header
       Given each row contains a number in decimal and binary form
             | 1 | 1  |
             | 2 | 10 |
             | 3 | 11 |
```

### In meta..
We specify the `@DataTable` tag on the StepDef with the `horizontal` attribute set to `decimal,binary` to assign names to the elements in each data record. We then reference the data using `data[name]` to access the 1st record (or the current record in a 'for each' step), or `data[recordNo][name]` to access any explicit record (where `recordNo` of 1st record is 1, 2nd is 2, and so on).
```gherkin
  @StepDef
  @DataTable(horizontal="decimal,binary")
  Scenario: each row contains a number in decimal and binary form
      Given name[1] should be "decimal"
        And name[2] should be "binary"
        And data[decimal] should be "1"
        And data[1][decimal] should be "1"
        And data[2][decimal] should be "2"
        And data[3][decimal] should be "3"
        And data[binary] should be "1"
        And data[1][binary] should be "1"
        And data[2][binary] should be "10"
        And data[3][binary] should be "11"
        And the decimal data[decimal] should be data[binary] in binary for each data record

  @StepDef
  Scenario: the decimal <decimal> should be <binary> in binary
     Given the result is defined by javascript "Number(${$<decimal>}).toString(2)"
      Then the result should be "${$<binary>}"
```

# Vertical Data Tables

## With header

This example has 3 rows and 3 columns of data and a left header. The first vertical column is the header and the columns that follow are data records.

### In feature..
```gherkin
   Scenario: Vertical table with header
       Given each column contains a number and its square and cube
             | number | 1 | 2 | 3  |
             | square | 1 | 4 | 9  |
             | cube   | 1 | 8 | 27 |
```

### In meta..
We specify the `@DataTable` tag on the StepDef with the `header` attribute set to `left` to assign the names in the left header record to the elements in each data record. We then reference the data using `data[name]` to access the 1st record (or the current record in a 'for each' step), or `data[recordNo][name]` to access any explicit record (where `recordNo` of 1st record is 1, 2nd is 2, and so on).
```gherkin
  @StepDef
  @DataTable(header="left")
  Scenario: each column contains a number and its square and cube
      Given name[1] should be "number"
        And name[2] should be "square"
        And name[3] should be "cube"
        And data[number] should be "1"
        And data[1][number] should be "1"
        And data[2][number] should be "2"
        And data[3][number] should be "3"
        And data[square] should be "1"
        And data[1][square] should be "1"
        And data[2][square] should be "4"
        And data[3][square] should be "9"
        And data[cube] should be "1"
        And data[1][cube] should be "1"
        And data[2][cube] should be "8"
        And data[3][cube] should be "27"
        And number ^ 2 = square of number for each data record
        And number ^ 3 = cube of number for each data record
  @StepDef
  Scenario: number ^ <power> = <function> of number
      Given the result is defined by javascript "Math.pow(${data[number]}, $<power>)"
       Then the result should be "${data[$<function>]}.0"
```

## Without header

This example has 2 rows and 3 columns of data and no header. Each vertical row is a data record.

### In feature..
```gherkin
   Scenario: Vertical data table with no header
       Given each column contains a number in decimal and binary form
             | 4   | 5    | 6   |
             | 100 | 101  | 110 |
```

### In meta..
We specify the `@DataTable` tag on the StepDef with the `vertical` attribute set to `decimal,binary` to assign names to the elements in each data record. We then reference the data using `data[name]` to access the 1st record (or the current record in a 'for each' step), or `data[recordNo][name]` to access any explicit record (where `recordNo` of 1st record is 1, 2nd is 2, and so on).
```gherkin
  @StepDef
  @DataTable(vertical="decimal,binary")
  Scenario: each column contains a number in decimal and binary form
      Given name[1] should be "decimal"
        And name[2] should be "binary"
        And data[decimal] should be "4"
        And data[1][decimal] should be "4"
        And data[2][decimal] should be "5"
        And data[3][decimal] should be "6"
        And data[binary] should be "100"
        And data[1][binary] should be "100"
        And data[2][binary] should be "101"
        And data[3][binary] should be "110"
        And the decimal data[decimal] should be data[binary] in binary for each data record

  @StepDef
  Scenario: the decimal <decimal> should be <binary> in binary
     Given the result is defined by javascript "Number(${$<decimal>}).toString(2)"
      Then the result should be "${$<binary>}"
```

# Matrix Tables
A matrix has a top and left headers around contained data. That data can only be accessed by top-left coordinates and so there is no concept of records in a matrix.

This example has 3 rows and 3 columns of data and top and left headers. The first row (excluding the first element is the top header and the first column (excluding the first element) is the left header. The data exists below and to the right of these headers respectively.

### In feature..
```gherkin
   Scenario: Matrix table with top and left headers
       Given the top and left numbers yield the product in the matrix
             | x | 1 | 2 | 3 |
             | 1 | 1 | 2 | 3 |
             | 2 | 2 | 4 | 6 |
             | 3 | 3 | 6 | 9 |
```

### In meta..
We specify the `@DataTable` tag on the StepDef with the `type` attribute set to `matrix` to assign top-left header coordinates to the data elements in the matrix. We can then reference the names in the top and left headers using `top.name[columnNo]` and `left.name[rowNo]` respectively (where both `columnNo` and `rowNo` are 1 for the 1st header element, 2 for 2nd and so on). The name of the header element at top-left corner can be accessed as `vertex.name`. The data can be accessed using `data[top-name][left-name]` (where `top-name` and `left-name` are the top and left header names of the row and column where the data resides - they just happen to also be numbers in this example). 
```gherkin
  @StepDef
  @DataTable(type="matrix")
  Scenario: the top and left numbers yield the product in the matrix
      Given vertex.name should be "x"
        And top.name[1] should be "1"
        And top.name[2] should be "2"
        And top.name[3] should be "3"
        And left.name[1] should be "1"
        And left.name[2] should be "2"
        And left.name[3] should be "3"
        And data[1][1] should be "1"
        And data[1][2] should be "2"
        And data[1][3] should be "3"
        And data[2][1] should be "2"
        And data[2][2] should be "4"
        And data[2][3] should be "6"
        And data[3][1] should be "3"
        And data[3][2] should be "6"
        And data[3][3] should be "9"
        And top.name[1] x left.name[1] = data[1][1]
        And top.name[2] x left.name[1] = data[2][1]
        And top.name[3] x left.name[1] = data[3][1]
        And top.name[1] x left.name[2] = data[1][2]
        And top.name[2] x left.name[2] = data[2][2]
        And top.name[3] x left.name[2] = data[3][2]
        And top.name[1] x left.name[3] = data[1][3]
        And top.name[2] x left.name[3] = data[2][3]
        And top.name[3] x left.name[3] = data[3][3]

  @StepDef
  Scenario: <a> x <b> = <c>
      Given the product is defined by javascript "${$<a>} * ${$<b>}"
       Then the product should be "${$<c>}"
```

## Sample Reports

### Compact

<img width="638" alt="tables-compact" src="https://user-images.githubusercontent.com/1369994/27796966-39595bc4-604f-11e7-92db-7700eaa40633.png">

### Expanded

<img width="642" alt="tables-expanded" src="https://user-images.githubusercontent.com/1369994/27839812-a386bb8e-6137-11e7-9a1b-1a19e87e75c9.png">

