### PR TITLE
Feature doc strings

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 =====
 Jul 14, 2017
 - Add support for DocStrings
+- Evaluate all javascript expressions in anonymous function block
 
 2.7.3
 =====

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+2.8.0
+=====
+Jul 14, 2017
+- Add support for DocStrings
+
 2.7.3
 =====
 Jul 11, 2017

--- a/features/sample/docStrings/DocStrings.feature
+++ b/features/sample/docStrings/DocStrings.feature
@@ -17,8 +17,9 @@
  Feature: DocStrings
 
    Scenario: Javascript DocString binding
-       Given my value is a function binding
-        Then my value should be "true"
+       Given the current date is formatted as yyyy-mm-dd
+        Then the current date should match regex "\d{4}-\d{2}-\d{2}"
+         And the current date should be "${the current date}"
 
    Scenario: Paragraph of text
        Given my paragraph is
@@ -52,7 +53,7 @@
    Scenario: Multi paragraph text with interpolation
        Given my attribute 1 is "Given-When-Then"
          And my attribute 2 is "automation"
-         And my line is
+         And my paragraph is
              """
              Gwen is a Gherkin interpreter that turns ${my attribute 1} steps into ${my attribute 2} instructions and
              executes them for you so you don't have to do all the programming work. It has an abstracted evaluation
@@ -62,7 +63,7 @@
              you to compose step definitions by mapping 'declarative' steps in features to 'imperative' steps in engines
              that perform operations.
              """
-        Then my line should be
+        Then my paragraph should be
              """
              Gwen is a Gherkin interpreter that turns Given-When-Then steps into automation instructions and
              executes them for you so you don't have to do all the programming work. It has an abstracted evaluation
@@ -74,16 +75,13 @@
              """
 
    Scenario: Single line of text with content type
-       Given my text line is
+       Given my line is
              """text
              Gwen is a Gherkin interpreter that turns Given-When-Then steps into automation instructions.
              """
-        Then my text line should be
+        Then my line should be
              """text
              Gwen is a Gherkin interpreter that turns Given-When-Then steps into automation instructions.
              """
-         And my text line should be "Gwen is a Gherkin interpreter that turns Given-When-Then steps into automation instructions."
+         And my line should be "Gwen is a Gherkin interpreter that turns Given-When-Then steps into automation instructions."
 
-   Scenario: Javascript Inline binding
-       Given my function value is defined by javascript "function myValue() { return true; } myValue();"
-        Then my function value should be "true"

--- a/features/sample/docStrings/DocStrings.feature
+++ b/features/sample/docStrings/DocStrings.feature
@@ -1,0 +1,95 @@
+#
+# Copyright 2017 Branko Juric, Brady Wood
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+ Feature: DocStrings
+
+   Scenario: Javascript DocString binding
+       Given my function value is defined by javascript
+             """JavaScript
+             function myValue() {
+               return true;
+             }
+             myValue();
+             """
+        Then my function value should be "true"
+
+   Scenario: Paragraph of text
+       Given my paragraph is
+             """
+             Gwen is a Gherkin interpreter that turns Given-When-Then steps into automation instructions and executes
+             them for you so you don't have to do all the programming work. It has an abstracted evaluation engine
+             allowing any type of automation capability to be built and mixed in. Meta specifications (also expressed
+             in Gherkin) are used to capture automation bindings and allow you to compose step definitions by mapping
+             'declarative' steps in features to 'imperative' steps in engines that perform operations.
+             """
+        Then my paragraph should be
+             """
+             Gwen is a Gherkin interpreter that turns Given-When-Then steps into automation instructions and executes
+             them for you so you don't have to do all the programming work. It has an abstracted evaluation engine
+             allowing any type of automation capability to be built and mixed in. Meta specifications (also expressed
+             in Gherkin) are used to capture automation bindings and allow you to compose step definitions by mapping
+             'declarative' steps in features to 'imperative' steps in engines that perform operations.
+             """
+
+   Scenario: Single line of text
+       Given my line is
+             """
+             Gwen is a Gherkin interpreter that turns Given-When-Then steps into automation instructions.
+             """
+        Then my line should be
+             """
+             Gwen is a Gherkin interpreter that turns Given-When-Then steps into automation instructions.
+             """
+         And my line should be "Gwen is a Gherkin interpreter that turns Given-When-Then steps into automation instructions."
+
+   Scenario: Multi paragraph text with interpolation
+       Given my attribute 1 is "Given-When-Then"
+         And my attribute 2 is "automation"
+         And my line is
+             """
+             Gwen is a Gherkin interpreter that turns ${my attribute 1} steps into ${my attribute 2} instructions and
+             executes them for you so you don't have to do all the programming work. It has an abstracted evaluation
+             engine allowing any type of ${my attribute 2} capability to be built and mixed in.
+
+             Meta specifications (also expressed in Gherkin) are used to capture ${my attribute 2} bindings and allow
+             you to compose step definitions by mapping 'declarative' steps in features to 'imperative' steps in engines
+             that perform operations.
+             """
+        Then my line should be
+             """
+             Gwen is a Gherkin interpreter that turns Given-When-Then steps into automation instructions and
+             executes them for you so you don't have to do all the programming work. It has an abstracted evaluation
+             engine allowing any type of automation capability to be built and mixed in.
+
+             Meta specifications (also expressed in Gherkin) are used to capture automation bindings and allow
+             you to compose step definitions by mapping 'declarative' steps in features to 'imperative' steps in engines
+             that perform operations.
+             """
+
+   Scenario: Single line of text with content type
+       Given my text line is
+             """text
+             Gwen is a Gherkin interpreter that turns Given-When-Then steps into automation instructions.
+             """
+        Then my text line should be
+             """text
+             Gwen is a Gherkin interpreter that turns Given-When-Then steps into automation instructions.
+             """
+         And my text line should be "Gwen is a Gherkin interpreter that turns Given-When-Then steps into automation instructions."
+
+   Scenario: Javascript Inline binding
+       Given my function value is defined by javascript "function myValue() { return true; } myValue();"
+        Then my function value should be "true"

--- a/features/sample/docStrings/DocStrings.feature
+++ b/features/sample/docStrings/DocStrings.feature
@@ -17,14 +17,8 @@
  Feature: DocStrings
 
    Scenario: Javascript DocString binding
-       Given my function value is defined by javascript
-             """JavaScript
-             function myValue() {
-               return true;
-             }
-             myValue();
-             """
-        Then my function value should be "true"
+       Given my value is a function binding
+        Then my value should be "true"
 
    Scenario: Paragraph of text
        Given my paragraph is

--- a/features/sample/docStrings/DocStrings.meta
+++ b/features/sample/docStrings/DocStrings.meta
@@ -18,7 +18,7 @@
 
    @StepDef
    Scenario: the current date is formatted as yyyy-mm-dd
-       Given the current is defined by javascript
+       Given the current date is defined by javascript
              """JavaScript
              (function() {
                var d = new Date();

--- a/features/sample/docStrings/DocStrings.meta
+++ b/features/sample/docStrings/DocStrings.meta
@@ -1,0 +1,27 @@
+#
+# Copyright 2017 Branko Juric, Brady Wood
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+ Feature: DocStrings Meta
+
+   @StepDef
+   Scenario: my value is a function binding
+       Given my value is defined by javascript
+             """JavaScript
+             function myValue() {
+               return true;
+             }
+             myValue();
+             """

--- a/features/sample/docStrings/DocStrings.meta
+++ b/features/sample/docStrings/DocStrings.meta
@@ -17,11 +17,14 @@
  Feature: DocStrings Meta
 
    @StepDef
-   Scenario: my value is a function binding
-       Given my value is defined by javascript
+   Scenario: the current date is formatted as yyyy-mm-dd
+       Given the current is defined by javascript
              """JavaScript
-             function myValue() {
-               return true;
-             }
-             myValue();
+             (function() {
+               var d = new Date();
+               var year = d.getFullYear();
+               var month = ('0' + (d.getMonth() + 1)).slice(-2);
+               var day = ('0' + d.getDate()).slice(-2);
+               return year + '-' + month + '-' + day;
+             })();
              """

--- a/features/sample/tables/NumberTables.feature
+++ b/features/sample/tables/NumberTables.feature
@@ -76,3 +76,15 @@
 
    Scenario: tables in nested stepdefs should not conflict
        Given nested tables should match the right tables
+
+
+   Scenario: Vertical data table with no header (with table interpolation)
+       Given four in decimal is "4"
+         And five in decimal is "5"
+         And six in decimal is "6"
+         And four in binary is "100"
+         And five in binary is "101"
+         And six in binary is "110"
+       Given each column contains a number in decimal and binary form
+             | ${four in decimal} | ${five in decimal} | ${six in decimal} |
+             | ${four in binary}  | ${five in binary}  | ${six in binary}  |

--- a/src/main/resources/gwen/report/html/css/gwen.css
+++ b/src/main/resources/gwen/report/html/css/gwen.css
@@ -258,3 +258,11 @@ table tbody.summary td {
 .data-table {
   color: #333333;
 }
+
+.doc-string {
+  color: #333333;
+}
+
+.doc-string-type {
+  color: gray;
+}

--- a/src/main/scala/gwen/Predefs.scala
+++ b/src/main/scala/gwen/Predefs.scala
@@ -231,6 +231,12 @@ object Predefs extends LazyLogging {
       val maxWidths = (table map { case (_, rows) => rows.map(_.length) }).transpose.map(_.max)
       s"| ${(table(rowIndex)._2.zipWithIndex map { case (data, dataIndex) => s"${rightPad(data, maxWidths(dataIndex))}" }).mkString(" | ") } |"
     }
+    def formatDocString(docString: (Int, String, Option[String]), includeType: Boolean = false) = docString match {
+      case (_, content, contentType) =>
+        s"""|${"\"\"\""}${if(includeType) contentType.getOrElse("") else ""}
+            |$content
+            |${"\"\"\""}""".stripMargin
+    }
   }
   
   object DurationOps {

--- a/src/main/scala/gwen/dsl/PrettyPrinter.scala
+++ b/src/main/scala/gwen/dsl/PrettyPrinter.scala
@@ -50,8 +50,12 @@ object prettyPrint {
       background.map(apply).getOrElse("") +
         (if (isOutline && scenario.examples.flatMap(_.scenarios).nonEmpty) "" else s"\n\n${formatTags("  ", tags)}  ${scenario.keyword}: $name${formatTextLines(description)}${formatStatus(scenario.evalStatus)}\n" + printAll(steps.map(apply), "  ", "\n")) +
         printAll(examples.map(apply), "", "\n")
-    case Step(keyword, expression, evalStatus, _, _, table) =>
-      rightJustify(keyword.toString) + s"$keyword $expression${formatStatus(evalStatus)}" + s"${if (table.nonEmpty) formatTextLines(table.indices.toList.map { rowIndex => Formatting.formatTableRow(table, rowIndex) }) else ""}"
+    case Step(keyword, name, evalStatus, _, _, table, docString) =>
+      rightJustify(keyword.toString) + s"$keyword $name${formatStatus(evalStatus)}" + s"${if (table.nonEmpty)
+        formatTextLines(table.indices.toList.map { rowIndex => Formatting.formatTableRow(table, rowIndex) })
+      else if (docString.nonEmpty)
+        formatTextLines(Formatting.formatDocString(docString.get).split("""\r?\n""").toList)
+      else ""}"
     case Examples(name, description, table, scenarios) => scenarios match {
       case Nil =>
         s"\n  ${Examples.keyword}: $name${formatTextLines(description)}${formatTextLines(table.indices.toList.map { rowIndex => Formatting.formatTableRow(table, rowIndex) })}"

--- a/src/main/scala/gwen/dsl/SpecNormaliser.scala
+++ b/src/main/scala/gwen/dsl/SpecNormaliser.scala
@@ -92,7 +92,15 @@ trait SpecNormaliser {
               outline.description.map(line => Formatting.resolveParams(line, params)),
               if (outline.isStepDef) None else background,
               outline.steps.map { s =>
-                new Step(s.keyword, Formatting.resolveParams(s.expression, params), s.status, s.attachments, s.stepDef) tap { step => step.pos = s.pos }
+                new Step(
+                  s.keyword,
+                  Formatting.resolveParams(s.name, params),
+                  s.status,
+                  s.attachments,
+                  s.stepDef,
+                  s.table map { case (line, record) => (line, record.map(cell => Formatting.resolveParams(cell, params))) },
+                  s.docString map { case (line, content, contentType) => (line, Formatting.resolveParams(content, params), contentType) }
+                ) tap { step => step.pos = s.pos }
               },
               isOutline = false,
               Nil,

--- a/src/main/scala/gwen/eval/EnvContext.scala
+++ b/src/main/scala/gwen/eval/EnvContext.scala
@@ -292,7 +292,7 @@ class EnvContext(options: GwenOptions, scopes: ScopedDataStack) extends Evaluata
       case (n, v) =>
         if (n == s"$name/text") v
         else if (n == s"$name/javascript")
-          evaluate(s"dryRun[javascript:$v]") {
+          evaluate("$[dryRun:javascript]") {
             Option(evaluateJS(jsReturn(interpolate(v)(getBoundReferenceValue)))).map(_.toString).getOrElse("")
           }
         else if (n.startsWith(s"$name/xpath")) {
@@ -311,10 +311,10 @@ class EnvContext(options: GwenOptions, scopes: ScopedDataStack) extends Evaluata
           val expression = interpolate(attScopes.get(s"$name/json path/expression"))(getBoundReferenceValue)
           evaluateJsonPath(expression, source)
         }
-        else if (n == s"$name/sysproc") evaluate(s"dryRun[sysproc:$v]") { v.!!.trim }
+        else if (n == s"$name/sysproc") evaluate("$[dryRun:sysproc]") { v.!!.trim }
         else if (n == s"$name/file") {
           val filepath = interpolate(v)(getBoundReferenceValue)
-          evaluate(s"dryRun[file:$v]") {
+          evaluate("$[dryRun:file]") {
             if (new File(filepath).exists()) {
               Source.fromFile(filepath).mkString
             } else throw new FileNotFoundException(s"File bound to '$name' not found: $filepath")
@@ -342,6 +342,8 @@ class EnvContext(options: GwenOptions, scopes: ScopedDataStack) extends Evaluata
           }
         }
       }
+    } tap { value =>
+      logger.debug(s"getBoundReferenceValue($name)='$value'")
     }
   
   def compare(expected: String, actual: String, operator: String, negate: Boolean): Boolean = {

--- a/src/main/scala/gwen/eval/EvalEngine.scala
+++ b/src/main/scala/gwen/eval/EvalEngine.scala
@@ -140,7 +140,7 @@ trait EvalEngine[T <: EnvContext] extends LazyLogging {
     }
     (if (isPriority) pStep else {
       if (iStep.evalStatus.status != StatusKeyword.Failed) {
-      Try(env.getStepDef(iStep.expression)) match {
+      Try(env.getStepDef(iStep.name)) match {
         case Failure(error) =>
           val failure = Failed(System.nanoTime - start, new StepFailure(step, error))
           env.fail(failure)

--- a/src/main/scala/gwen/eval/GwenREPL.scala
+++ b/src/main/scala/gwen/eval/GwenREPL.scala
@@ -36,6 +36,8 @@ import jline.console.completer.AggregateCompleter
 class GwenREPL[T <: EnvContext](val interpreter: GwenInterpreter[T], val env: T) {
 
   private val history = new FileHistory(new File(".history").getAbsoluteFile)
+
+  private var pasteBuffer: Option[List[String]] = None
   
   private lazy val reader = new ConsoleReader() tap { reader =>
     reader.setHistory(history)
@@ -79,7 +81,7 @@ class GwenREPL[T <: EnvContext](val interpreter: GwenInterpreter[T], val env: T)
           Some("""Try again using: env [-a|-f] ["filter"]""")
       }
     }
-    case r"history" =>
+    case "history" =>
       Some(history.toString)
     case r"!(\d+)$$$historyValue" =>
       val num = historyValue.toInt
@@ -92,7 +94,10 @@ class GwenREPL[T <: EnvContext](val interpreter: GwenInterpreter[T], val env: T)
       } else {
         Some(s"No such history: !$historyValue")
       }
-    case r"exit|bye|quit" => 
+    case "paste" =>
+      pasteBuffer = Some(List[String]())
+      Some("In paste mode (press ctrl-D when finished to evaluate)")
+    case "exit|bye|quit" =>
       reader.getHistory.asInstanceOf[FileHistory].flush()
       None
     case _ =>

--- a/src/main/scala/gwen/eval/support/DecodingSupport.scala
+++ b/src/main/scala/gwen/eval/support/DecodingSupport.scala
@@ -31,7 +31,7 @@ trait DecodingSupport {
     * @return the decoded result string
     */
   def decodeBase64(source: String): String =
-    evaluate(s"dryRun[base64Decoded]") {
+    evaluate("$[dryRun:decodeBase64]") {
       Option(source) match {
         case None =>
           decodingError("Cannot Base64 decode null string")

--- a/src/main/scala/gwen/eval/support/JsonPathSupport.scala
+++ b/src/main/scala/gwen/eval/support/JsonPathSupport.scala
@@ -35,7 +35,7 @@ trait JsonPathSupport {
     * @return the result of evaluating the json path expression
     */
   def evaluateJsonPath(jsonpath: String, source: String): String = {
-    evaluate(s"dryRun[json-path:$jsonpath]") {
+    evaluate("$[dryRun:json path]") {
       if (source.trim().length() == 0) {
         jsonPathError("Cannot evaluate Json path on empty source")
       }

--- a/src/main/scala/gwen/eval/support/RegexSupport.scala
+++ b/src/main/scala/gwen/eval/support/RegexSupport.scala
@@ -33,7 +33,7 @@ trait RegexSupport {
     * @throws gwen.errors.RegexException if the regex fails to evaluate
     */
   def extractByRegex(regex: String, source: String): String =
-    evaluate(s"dryRun[regex:$regex") {
+    evaluate("$[dryRun:regex]") {
       regex.r.findFirstMatchIn(source).getOrElse(regexError(s"'Regex match '$regex' not found in '$source'")).group(1)
     }
     

--- a/src/main/scala/gwen/eval/support/SQLSupport.scala
+++ b/src/main/scala/gwen/eval/support/SQLSupport.scala
@@ -34,7 +34,7 @@ trait SQLSupport {
     * @return the result of executing the SQL
     */
   def evaluateSql(sql: String, database: String): String =
-    evaluate(s"dryRun[sql:$sql]") {
+    evaluate("$[dryRun:sql]") {
       if (sql.trim().length() == 0) {
         sqlError("Cannot evaluate empty SQL statement")
       }

--- a/src/main/scala/gwen/eval/support/ScriptSupport.scala
+++ b/src/main/scala/gwen/eval/support/ScriptSupport.scala
@@ -38,7 +38,7 @@ trait ScriptSupport {
     * @param script the script expression to evaluate
     */
   private def evaluateScript[T](language: String, script: String): T =
-    new ScriptEngineManager(null).getEngineByName(language).eval(script).asInstanceOf[T]
+    new ScriptEngineManager(null).getEngineByName(language).eval(s"(function() { return $script })()").asInstanceOf[T]
 
 
 }

--- a/src/main/scala/gwen/eval/support/XPathSupport.scala
+++ b/src/main/scala/gwen/eval/support/XPathSupport.scala
@@ -56,7 +56,7 @@ trait XPathSupport {
     * @throws gwen.errors.XPathException if the xpath expression fails to evaluate
     */
   def evaluateXPath(xpath: String, source: String, targetType: XMLNodeType.Value): String =
-    evaluate(s"dryRun[xpath:$xpath]") {
+    evaluate("$[dryRun:xpath]") {
       if (source.trim().length() == 0) {
         xPathError("Cannot evaluate XPath on empty source")
       }

--- a/src/main/scala/gwen/report/JsonReportFormatter.scala
+++ b/src/main/scala/gwen/report/JsonReportFormatter.scala
@@ -145,7 +145,7 @@ trait JsonReportFormatter extends ReportFormatter {
     s"""
           {
             "keyword": "${step.keyword} ",
-            "name": "${escapeJson(step.expression)}",
+            "name": "${escapeJson(step.name)}",
             "line": ${step.pos.line},${if (screenshots.nonEmpty) s"""
             "embeddings": [${screenshots.map{ file => s"""
               {
@@ -158,7 +158,12 @@ trait JsonReportFormatter extends ReportFormatter {
                 s"""
             "match": {
                 "location": "${escapeJson(location)}"
-            },"""} else ""}.getOrElse("")}${if (step.table.nonEmpty) s"""
+            },"""} else ""}.getOrElse("")}${step.docString.map{ case (line, content, contentType) => s"""
+            "doc_string": {
+              "content_type": "${contentType.map(c => escapeJson(c)).getOrElse("")}",
+              "value": "${escapeJson(content)}",
+              "line": $line
+            },"""}.getOrElse("")}${if (step.table.nonEmpty) s"""
             "rows": [${step.table.zipWithIndex.map { case ((line, row), rIndex) =>
               val rowId = s"$parentId;${rIndex + 1};$line"
               s"""

--- a/src/test/scala/gwen/dsl/EvalStatusTest.scala
+++ b/src/test/scala/gwen/dsl/EvalStatusTest.scala
@@ -98,11 +98,11 @@ Background: The tester
           scenario.description,
           scenario.background map { background =>
             Background(background.name, background.description, background.steps map {step =>
-              Step(step.keyword, step.expression, Passed(1))
+              Step(step.keyword, step.name, Passed(1))
             })
           }, 
           scenario.steps map {step =>
-            Step(step.keyword, step.expression, if (scenario.isStepDef) Loaded else Passed(1))
+            Step(step.keyword, step.name, if (scenario.isStepDef) Loaded else Passed(1))
           }) 
       })
     
@@ -137,7 +137,7 @@ Background: The tester
           scenario.background map { background =>
             Background(background.name, background.description, background.steps.zipWithIndex map {zip =>
               val (step, stepIndex) = zip
-              Step(step.keyword, step.expression, stepIndex match {
+              Step(step.keyword, step.name, stepIndex match {
                 case 0 | 1 | 2 if scenarioIndex == 0 => Passed(1)
                 case 3 if scenarioIndex == 0 => Failed(99, error)
                 case _ => step.evalStatus
@@ -198,7 +198,7 @@ Background: The tester
           scenario.background map { background =>
             Background(background.name, background.description, background.steps.zipWithIndex map {zip =>
               val (step, stepIndex) = zip
-              Step(step.keyword, step.expression, stepIndex match {
+              Step(step.keyword, step.name, stepIndex match {
                 case 0 | 1 | 2 if scenarioIndex < 2 => Passed(1)
                 case 3 if scenarioIndex == 1 => Failed(99, error)
                 case _ => if (scenarioIndex < 1) Passed(1) else step.evalStatus
@@ -258,7 +258,7 @@ Background: The tester
           scenario.description, 
           scenario.background map { background =>
             Background(background.name, background.description, background.steps map { step =>
-              Step(step.keyword, step.expression, scenarioIndex match {
+              Step(step.keyword, step.name, scenarioIndex match {
                 case 0 => Passed(1)
                 case _ => step.evalStatus
               })
@@ -266,7 +266,7 @@ Background: The tester
           }, 
           scenario.steps.zipWithIndex map { zip =>
             val (step, stepIndex) = zip
-            Step(step.keyword, step.expression, stepIndex match {
+            Step(step.keyword, step.name, stepIndex match {
               case 0 | 1 | 2 if scenarioIndex == 0 => Passed(1)
               case 3 if scenarioIndex == 0 => Failed(99, error)
               case _ => step.evalStatus
@@ -326,12 +326,12 @@ Background: The tester
           scenario.description, 
           scenario.background map { background =>
             Background(background.name, background.description, background.steps map { step =>
-              Step(step.keyword, step.expression, Passed(1))
+              Step(step.keyword, step.name, Passed(1))
             }) 
           }, 
           scenario.steps.zipWithIndex map { zip =>
             val (step, stepIndex) = zip
-            Step(step.keyword, step.expression, stepIndex match {
+            Step(step.keyword, step.name, stepIndex match {
               case 0 | 1 | 2 if scenarioIndex < 2 => Passed(1)
               case 3 if scenarioIndex == 1 => Failed(99, error)
               case _ => if (scenarioIndex == 0) Passed(1) else step.evalStatus

--- a/src/test/scala/gwen/dsl/PrettyPrintParserTest.scala
+++ b/src/test/scala/gwen/dsl/PrettyPrintParserTest.scala
@@ -29,7 +29,7 @@ class PrettyPrintParserTest extends FlatSpec with Matchers with SpecNormaliser w
 
   private val parse = parseFeatureSpec(_: String)
 
-  private val featureString = """
+  private val featureString = s"""
    
      @wip
      Feature: Gwen
@@ -75,7 +75,14 @@ class PrettyPrintParserTest extends FlatSpec with Matchers with SpecNormaliser w
          Then the word should match the number
          | one   | 1 |
          | two   | 2 |
-         | three | 3 |"""
+         | three | 3 |
+
+    Scenario: Multiline DocString
+        Given my line is
+              ${"\"\"\""}
+              Gwen is a Gherkin interpreter that turns
+              Given-When-Then steps into automation instructions.
+              ${"\"\"\""}"""
  
   "parsing pretty printed Gwen feature" should "yield same AST" in {
     
@@ -121,7 +128,7 @@ class PrettyPrintParserTest extends FlatSpec with Matchers with SpecNormaliser w
   "pretty print of parsed Gwen feature" should "not be normalised" in {
     
     val specFeature = parse(featureString).get
-    prettyPrint(specFeature).replace("\r", "") should be ("""   @wip
+    prettyPrint(specFeature).replace("\r", "") should be (s"""   @wip
    Feature: Gwen
             As a tester
             I want to automate tests
@@ -165,14 +172,21 @@ Background: The butterfly effect
        Then the word should match the number
             | one   | 1 |
             | two   | 2 |
-            | three | 3 |""".replace("\r", ""))
+            | three | 3 |
+
+  Scenario: Multiline DocString
+      Given my line is
+            ${"\"\"\""}
+            Gwen is a Gherkin interpreter that turns
+            Given-When-Then steps into automation instructions.
+            ${"\"\"\""}""".replace("\r", ""))
     
   }
 
   "pretty print of normalised Gwen feature" should "replicate background for each expanded scenario" in {
 
     val specFeature = normalise(parse(featureString).get, None, None)
-    prettyPrint(specFeature).replace("\r", "") should be ("""   @wip
+    prettyPrint(specFeature).replace("\r", "") should be (s"""   @wip
    Feature: Gwen
             As a tester
             I want to automate tests
@@ -242,7 +256,20 @@ Background: The butterfly effect
        Then the word should match the number
             | one   | 1 |
             | two   | 2 |
-            | three | 3 |""".replace("\r", ""))
+            | three | 3 |
+
+Background: The butterfly effect
+            Sensitivity to initial conditions
+      Given a deterministic nonlinear system
+       When a small change is initially applied
+       Then a large change will eventually result
+
+  Scenario: Multiline DocString
+      Given my line is
+            ${"\"\"\""}
+            Gwen is a Gherkin interpreter that turns
+            Given-When-Then steps into automation instructions.
+            ${"\"\"\""}""".replace("\r", ""))
 
   }
     

--- a/src/test/scala/gwen/eval/GwenInterpreterTest.scala
+++ b/src/test/scala/gwen/eval/GwenInterpreterTest.scala
@@ -81,7 +81,7 @@ class GwenInterpreterTest extends FlatSpec with Matchers with MockitoSugar {
     result match {
       case TrySuccess(s) =>
         s.keyword should be (StepKeyword.Given)
-        s.expression should be ("I am a valid step")
+        s.name should be ("I am a valid step")
         s.evalStatus.status should be (StatusKeyword.Passed)
       case TryFailure(err) =>
         err.printStackTrace()
@@ -108,7 +108,7 @@ class GwenInterpreterTest extends FlatSpec with Matchers with MockitoSugar {
     result match {
       case TrySuccess(step) =>
         step.keyword should be (StepKeyword.Given)
-        step.expression should be ("I am a valid stepdef")
+        step.name should be ("I am a valid stepdef")
         step.evalStatus.status should be (StatusKeyword.Passed)
       case TryFailure(err) =>
         fail(s"success expected but got $err")

--- a/src/test/scala/gwen/eval/support/ScriptSupportTest.scala
+++ b/src/test/scala/gwen/eval/support/ScriptSupportTest.scala
@@ -28,7 +28,11 @@ class ScriptSupportTest extends FlatSpec with Matchers with ScriptSupport {
     val booleanResult: Boolean = evaluateJavaScript("1 == 2")
     booleanResult should be(false)
 
-    val date: String = evaluateJavaScript("var d = new Date(2017, 6, 8); d.getDate()  + '/' + (d.getMonth()) + '/' + d.getFullYear();")
+    val date: String = evaluateJavaScript(
+      """(function() {
+        |  var d = new Date(2017, 6, 8);
+        |  return d.getDate()  + '/' + (d.getMonth()) + '/' + d.getFullYear();
+        |})();""".stripMargin)
     date should be ("8/6/2017")
   }
 

--- a/src/test/scala/gwen/eval/support/XPathSupportTest.scala
+++ b/src/test/scala/gwen/eval/support/XPathSupportTest.scala
@@ -81,7 +81,7 @@ class XPathSupportTest extends FlatSpec with Matchers {
 
   "match in dry run" should "not evalaute" in {
     val support: XPathSupport = new EnvContext(GwenOptions(dryRun = true), new ScopedDataStack())
-    support.evaluateXPath("root", XmlSource, support.XMLNodeType.node) should be ("dryRun[xpath:root]")
+    support.evaluateXPath("root", XmlSource, support.XMLNodeType.node) should be ("$[dryRun:xpath]")
   }
   
   private def compact(source: String): String = source.replace("\r", "").split('\n').map(_.trim()).mkString

--- a/src/test/scala/gwen/sample/docStrings/DocStringsInterpreterTest.scala
+++ b/src/test/scala/gwen/sample/docStrings/DocStringsInterpreterTest.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2017 Branko Juric, Brady Wood
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gwen.sample.docStrings
+
+import gwen.dsl.Failed
+import gwen.dsl.Passed
+import gwen.eval.GwenOptions
+import java.io.File
+
+import org.scalatest.FlatSpec
+import gwen.eval.GwenLauncher
+import gwen.report.ReportFormat
+import gwen.eval.ScopedDataStack
+import gwen.eval.EnvContext
+import gwen.eval.GwenInterpreter
+import gwen.eval.GwenApp
+import gwen.eval.support.DefaultEngineSupport
+
+class DocStringsEnvContext(val options: GwenOptions, val scopes: ScopedDataStack)
+  extends EnvContext(options, scopes) {
+  override def dsl: List[String] = Nil
+}
+
+trait DocStringsEvalEngine extends DefaultEngineSupport[DocStringsEnvContext] {
+  override def init(options: GwenOptions, scopes: ScopedDataStack): DocStringsEnvContext = new DocStringsEnvContext(options, scopes)
+}
+
+class DocStringsInterpreter
+  extends GwenInterpreter[DocStringsEnvContext]
+  with DocStringsEvalEngine
+
+object DocStringsInterpreter
+  extends GwenApp(new DocStringsInterpreter)
+
+class DocStringsInterpreterTest extends FlatSpec {
+  
+  "DDocStrings" should "evaluate without error" in {
+    
+    val options = GwenOptions(
+      batch = true,
+      reportDir = Some(new File("target/report/docStrings")),
+      reportFormats = List(ReportFormat.html, ReportFormat.junit, ReportFormat.json),
+      features = List(new File("features/sample/docStrings"))
+    )
+      
+    val launcher = new GwenLauncher(new DocStringsInterpreter())
+    launcher.run(options, None) match {
+      case Passed(_) => // excellent :)
+      case Failed(_, error) => error.printStackTrace(); fail(error.getMessage)
+      case _ => fail("evaluation expected but got noop")
+    }
+  }
+  
+  "DocStrings" should "pass --dry-run test" in {
+    
+    val options = GwenOptions(
+      batch = true,
+      reportDir = Some(new File("target/report/docStrings-dry-run")),
+      reportFormats = List(ReportFormat.html, ReportFormat.junit, ReportFormat.json),
+      features = List(new File("features/sample/docStrings")),
+      dryRun = true
+    )
+      
+    val launcher = new GwenLauncher(new DocStringsInterpreter())
+    launcher.run(options, None) match {
+      case Passed(_) => // excellent :)
+      case Failed(_, error) => error.printStackTrace(); fail(error.getMessage)
+      case _ => fail("evaluation expected but got noop")
+    }
+  }
+  
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,6 +1,6 @@
 enablePlugins(GitVersioning)
 
-git.baseVersion := "2.7.3"
+git.baseVersion := "2.8.0"
 
 git.useGitDescribe := true
 


### PR DESCRIPTION
Doc Strings
=========

This PR adds [Doc Strings](https://cucumber.io/docs/reference#doc-strings) to Gwen. So every step in the Gwen DSL that includes a string literal parameter surrounded by quotes at the end of the step expression can now accept a Doc String value.

This is handy when you want to specify a multiline string literal as the last parameter to a step.

Some examples follow..

## Multiline Text

One use case is multiline strings. In the absence of Doc Strings there was no way to pass in multiline strings or paragraphs of text. You can now do this as follows:

```
Given my paragraph is
     """
     Gwen is a Gherkin interpreter that turns Given-When-Then steps into automation instructions and executes
     them for you so you don't have to do all the programming work. It has an abstracted evaluation engine
     allowing any type of automation capability to be built and mixed in. Meta specifications (also expressed
     in Gherkin) are used to capture automation bindings and allow you to compose step definitions by mapping
     'declarative' steps in features to 'imperative' steps in engines that perform operations.
     """
```

## JavaScript Function Bindings

Another use case is JavaScript bindings. In Gwen, they are limited to one-liner expressions. A work around for working with multiline javascript functions is to wrap the entire script in the body of an anonymous function and invoke it inline.

For example, consider the following script that returns the current date in yyyy-mm-dd format.

```JavaScript
(function() {
  var d = new Date();
  var year = d.getFullYear();
  var month = ('0' + (d.getMonth() + 1)).slice(-2);
  var day = ('0' + d.getDate()).slice(-2);
  return year + '-' + month + '-' + day;
})();
```

In the absence of Doc Strings, you would have to compact this to a one-liner expression and use it as follows (which is inelegant and hard to read):
```
Given the current date is defined by javascript "(function() {var d = new Date(); var year = d.getFullYear(); var month = ('0' + (d.getMonth() + 1)).slice(-2); var day = ('0' + d.getDate()).slice(-2); return year + '-' + month + '-' + day; })();"
```

With Doc Strings, you can now do this as follows instead:
```
Given the current date is defined by javascript
     """
     (function() {
       var d = new Date();
       var year = d.getFullYear();
       var month = ('0' + (d.getMonth() + 1)).slice(-2);
       var day = ('0' + d.getDate()).slice(-2);
       return year + '-' + month + '-' + day;
     })();
     """
```

## Sample Reports

The javascript Doc String in this report includes the optional `JavaScript` content type annotation at the opening triple quotes`"""`. Currently, Gwen just renders this literal in grey, but could in future use it for syntax highlighting.

<img width="945" alt="docstring" src="https://user-images.githubusercontent.com/1369994/28200258-51483bee-68ae-11e7-8e79-9d4fb14f3db1.png">


