### PR TITLE
Gwen template matching

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,20 @@
+2.13.0
+======
+Mar 4, 2018
+- Introduce template matching
+  - The following DSL's where introduced
+    - `<reference> <should|should not> match template "<expression>"`
+    - `<reference> <should|should not> match template file "<filepath>"`
+    - `<source> at <json path|xpath> "<path>" <should|should not> match template "<expression>"`
+    - `<source> at <json path|xpath> "<path>" <should|should not> match template file "<filepath>"`
+  - Template expressions may contain:
+    - Extract attributes: `@{name}`
+      - Extracts and binds the source value at `@{name}` in the template to the `name` attribute in the feature scope
+    - Ignore values: `@{}`
+      - Ignores the source value at `@{}` in the template
+    - Inject values: `${name}`
+      - Injects the value bound to the `name` attribute into `${name}` in the template
+
 2.12.6
 ======
 Mar 3, 2018

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,8 +10,8 @@ Mar 4, 2018
   - Template expressions may contain:
     - Extract attributes: `@{name}`
       - Extracts and binds the source value at `@{name}` in the template to the `name` attribute in the feature scope
-    - Ignore values: `@{}`
-      - Ignores the source value at `@{}` in the template
+    - Ignore values: `!{}`
+      - Ignores the source value at `!{}` in the template
     - Inject values: `${name}`
       - Injects the value bound to the `name` attribute into `${name}` in the template
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ to capture automation bindings and allow you to compose step definitions in a de
 
 - [Latest release](https://github.com/gwen-interpreter/gwen/releases/latest)
 - [Change log](CHANGELOG)
+- [User groups](#user-groups)
+
+### What's New?
+
+- [Template matching](https://github.com/gwen-interpreter/gwen/wiki/Template-Matching)
+- [Gwen Workspaces](https://gweninterpreter.wordpress.com/2017/12/18/gwen-workspaces/)
 
 Why Gwen?
 ---------
@@ -23,7 +29,8 @@ Why Gwen?
 > Gwen = [G]iven [W]hen Th[en]
 
 We wanted to make automation easier for non developers with little to no coding experience. So we developed an
-interpreter to read plain text Gherkin features as input and produce executing automation instructions as output through automation engines that can be developed and shared.
+interpreter to read plain text Gherkin features as input and produce executing automation instructions as output
+through automation engines that can be developed and shared.
 
 What engines are available?
 ---------------------------
@@ -64,12 +71,14 @@ Key Features
 - [SQL data bindings](https://github.com/gwen-interpreter/gwen/wiki/SQL-Data-Bindings)
 - [Implicit attributes](https://github.com/gwen-interpreter/gwen/wiki/Implicit-Attributes)
 
-Mail Group
-----------
+User Groups
+-----------
 
-All announcements and discussions are posted and broadcast to all members in the following mail group. You are welcome to visit and join to receive notifications or get involved.
+All announcements and discussions are posted and broadcast to all members in the
+[Gwen mail group](https://groups.google.com/d/forum/gwen-interpreter). Active users who join the mailing group will
+also receive an invitation to our Gwen Slack community where they can interact with other users and get more involved.
 
-- [Gwen mail group](https://groups.google.com/d/forum/gwen-interpreter)
+-
 
 Credits
 -------

--- a/features/sample/templates/MatchJsonTemplates.feature
+++ b/features/sample/templates/MatchJsonTemplates.feature
@@ -1,0 +1,134 @@
+#
+# Copyright 2018 Branko Juric, Brady Wood
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+  Feature: Match and extract JSON templates
+
+
+ Scenario: Init
+     Given my pet status is "available"
+
+
+ Scenario: Match static single line JSON template
+     Given my value is
+           """
+           {"id":42,"category":{"name":"pet"},"name":"tiger","status":"available"}
+           """
+      Then my value should match template "{"id":42,"category":{"name":"pet"},"name":"tiger","status":"available"}"
+       And my value should match template
+           """
+           {"id":42,"category":{"name":"pet"},"name":"tiger","status":"available"}
+           """
+       And my value should match template file "features/sample/templates/json/StaticSingleLineTemplate.json"
+
+
+ Scenario: Match static multi line JSON template
+     Given my value is
+           """
+           {
+             "id": 42,
+             "category": {
+               "name": "pet"
+             },
+             "name": "tiger",
+             "status": "available"
+           }
+           """
+      Then my value should not match template "{"id":42,"category":{"name":"pet"},"name":"tiger","status":"available"}"
+       And my value should match template
+           """
+           {
+             "id": 42,
+             "category": {
+               "name": "pet"
+             },
+             "name": "tiger",
+             "status": "available"
+           }
+           """
+       And my value should match template file "features/sample/templates/json/StaticMultiLineTemplate.json"
+
+
+ Scenario: Match dynamic single line JSON template (1 ignore, 1 extract, 1 inject)
+     Given my value is
+           """
+           {"id":42,"category":{"name":"pet"},"name":"tiger","status":"available"}
+           """
+      Then my value should match template "{"id":@{},"category":{"name":"pet"},"name":"@{pet name}","status":"${my pet status}"}"
+       And category name should be absent
+       And pet id should be absent
+       And pet name should be "tiger"
+
+
+ Scenario: Match dynamic multi line JSON template (2 extracts, 1 ignore, 1 inject)
+     Given my value is
+           """
+           {
+             "id": 42,
+             "category": {
+               "name": "pet"
+             },
+             "name": "tiger",
+             "status": "available"
+           }
+           """
+      Then my value should match template
+           """
+           {
+             "id": @{pet id},
+             "category": {
+               "name": "@{category name}"
+             },
+             "name": "@{}",
+             "status": "${my pet status}"
+           }
+           """
+       And pet id should be "42"
+       And category name should be "pet"
+       And the pet name is defined in my value by json path "$.name"
+       And the pet name should be "tiger"
+       And the pet status is defined in my value by json path "$.status"
+       And the pet status should be "available"
+
+
+ Scenario: Match dynamic single line JSON template file (1 ignore, 1 extract, 1 inject)
+     Given my value is
+           """
+           {"id":42,"category":{"name":"pet"},"name":"tiger","status":"available"}
+           """
+      Then my value should match template file "features/sample/templates/json/DynamicSingleLineTemplate.json"
+       And category name 1 should be absent
+       And pet id 1 should be absent
+       And pet name 1 should be "tiger"
+
+  Scenario: Match dynamic multi line JSON template file (2 extracts, 1 ignore, 1 inject)
+     Given my value is
+           """
+           {
+             "id": 42,
+             "category": {
+               "name": "pet"
+             },
+             "name": "tiger",
+             "status": "available"
+           }
+           """
+      Then my value should match template file "features/sample/templates/json/DynamicMultiLineTemplate.json"
+       And pet id 2 should be "42"
+       And category name 2 should be "pet"
+       And the pet name is defined in my value by json path "$.name"
+       And the pet name should be "tiger"
+       And the pet status is defined in my value by json path "$.status"
+       And the pet status should be "available"

--- a/features/sample/templates/MatchJsonTemplates.feature
+++ b/features/sample/templates/MatchJsonTemplates.feature
@@ -66,7 +66,7 @@
            """
            {"id":42,"category":{"name":"pet"},"name":"tiger","status":"available"}
            """
-      Then my value should match template "{"id":@{},"category":{"name":"pet"},"name":"@{pet name}","status":"${my pet status}"}"
+      Then my value should match template "{"id":!{},"category":{"name":"pet"},"name":"@{pet name}","status":"${my pet status}"}"
        And category name should be absent
        And pet id should be absent
        And pet name should be "tiger"
@@ -91,7 +91,7 @@
              "category": {
                "name": "@{category name}"
              },
-             "name": "@{}",
+             "name": "!{}",
              "status": "${my pet status}"
            }
            """

--- a/features/sample/templates/MatchXmlTemplates.feature
+++ b/features/sample/templates/MatchXmlTemplates.feature
@@ -1,0 +1,134 @@
+#
+# Copyright 2018 Branko Juric, Brady Wood
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+  Feature: Match and extract XML templates
+
+
+ Scenario: Init
+     Given my pet status is "available"
+
+
+ Scenario: Match static single line XML template
+     Given my value is
+           """
+           <result><id>42</id><category><name>pet</name></category><name>tiger</name><status>available</status></result>
+           """
+      Then my value should match template "<result><id>42</id><category><name>pet</name></category><name>tiger</name><status>available</status></result>"
+       And my value should match template
+           """
+           <result><id>42</id><category><name>pet</name></category><name>tiger</name><status>available</status></result>
+           """
+       And my value should match template file "features/sample/templates/xml/StaticSingleLineTemplate.xml"
+
+
+ Scenario: Match static multi line XML template
+     Given my value is
+           """
+           <result>
+               <id>42</id>
+               <category>
+                   <name>pet</name>
+               </category>
+               <name>tiger</name>
+               <status>available</status>
+           </result>
+           """
+      Then my value should not match template "<result><id>42</id><category><name>pet</name></category><name>tiger</name><status>available</status></result>"
+       And my value should match template
+           """
+           <result>
+               <id>42</id>
+               <category>
+                   <name>pet</name>
+               </category>
+               <name>tiger</name>
+               <status>available</status>
+           </result>
+           """
+       And my value should match template file "features/sample/templates/xml/StaticMultiLineTemplate.xml"
+
+
+ Scenario: Match dynamic single line XML template (1 ignore, 1 extract, 1 inject)
+     Given my value is
+           """
+           <result><id>42</id><category><name>pet</name></category><name>tiger</name><status>available</status></result>
+           """
+      Then my value should match template "<result><id>@{}</id><category><name>pet</name></category><name>@{pet name}</name><status>${my pet status}</status></result>"
+       And category name should be absent
+       And pet id should be absent
+       And pet name should be "tiger"
+
+
+ Scenario: Match dynamic multi line XML template (2 extracts, 1 ignore, 1 inject)
+     Given my value is
+           """
+           <result>
+               <id>42</id>
+               <category>
+                   <name>pet</name>
+               </category>
+               <name>tiger</name>
+               <status>available</status>
+           </result>
+           """
+      Then my value should match template
+           """
+           <result>
+               <id>@{pet id}</id>
+               <category>
+                   <name>@{category name}</name>
+               </category>
+               <name>@{}</name>
+               <status>${my pet status}</status>
+           </result>
+           """
+       And pet id should be "42"
+       And category name should be "pet"
+       And the pet name is defined by the text in my value by xpath "result/name"
+       And the pet name should be "tiger"
+       And the pet status is defined by the text in my value by xpath "result/status"
+       And the pet status should be "available"
+
+
+ Scenario: Match dynamic single line XML template file (1 ignore, 1 extract, 1 inject)
+     Given my value is
+           """
+           <result><id>42</id><category><name>pet</name></category><name>tiger</name><status>available</status></result>
+           """
+      Then my value should match template file "features/sample/templates/xml/DynamicSingleLineTemplate.xml"
+       And category name 1 should be absent
+       And pet id 1 should be absent
+       And pet name 1 should be "tiger"
+
+  Scenario: Match dynamic multi line XML template file (2 extracts, 1 ignore, 1 inject)
+     Given my value is
+           """
+           <result>
+               <id>42</id>
+               <category>
+                   <name>pet</name>
+               </category>
+               <name>tiger</name>
+               <status>available</status>
+           </result>
+           """
+      Then my value should match template file "features/sample/templates/xml/DynamicMultiLineTemplate.xml"
+       And pet id 2 should be "42"
+       And category name 2 should be "pet"
+       And the pet name is defined by the text in my value by xpath "result/name"
+       And the pet name should be "tiger"
+       And the pet status is defined by the text in my value by xpath "result/status"
+       And the pet status should be "available"

--- a/features/sample/templates/MatchXmlTemplates.feature
+++ b/features/sample/templates/MatchXmlTemplates.feature
@@ -66,7 +66,7 @@
            """
            <result><id>42</id><category><name>pet</name></category><name>tiger</name><status>available</status></result>
            """
-      Then my value should match template "<result><id>@{}</id><category><name>pet</name></category><name>@{pet name}</name><status>${my pet status}</status></result>"
+      Then my value should match template "<result><id>!{}</id><category><name>pet</name></category><name>@{pet name}</name><status>${my pet status}</status></result>"
        And category name should be absent
        And pet id should be absent
        And pet name should be "tiger"
@@ -91,7 +91,7 @@
                <category>
                    <name>@{category name}</name>
                </category>
-               <name>@{}</name>
+               <name>!{}</name>
                <status>${my pet status}</status>
            </result>
            """

--- a/features/sample/templates/json/DynamicMultiLineTemplate.json
+++ b/features/sample/templates/json/DynamicMultiLineTemplate.json
@@ -1,0 +1,8 @@
+{
+  "id": @{pet id 2},
+  "category": {
+    "name": "@{category name 2}"
+  },
+  "name": "@{}",
+  "status": "${my pet status}"
+}

--- a/features/sample/templates/json/DynamicMultiLineTemplate.json
+++ b/features/sample/templates/json/DynamicMultiLineTemplate.json
@@ -3,6 +3,6 @@
   "category": {
     "name": "@{category name 2}"
   },
-  "name": "@{}",
+  "name": "!{}",
   "status": "${my pet status}"
 }

--- a/features/sample/templates/json/DynamicSingleLineTemplate.json
+++ b/features/sample/templates/json/DynamicSingleLineTemplate.json
@@ -1,1 +1,1 @@
-{"id":@{},"category":{"name":"pet"},"name":"@{pet name 1}","status":"${my pet status}"}
+{"id":!{},"category":{"name":"pet"},"name":"@{pet name 1}","status":"${my pet status}"}

--- a/features/sample/templates/json/DynamicSingleLineTemplate.json
+++ b/features/sample/templates/json/DynamicSingleLineTemplate.json
@@ -1,0 +1,1 @@
+{"id":@{},"category":{"name":"pet"},"name":"@{pet name 1}","status":"${my pet status}"}

--- a/features/sample/templates/json/StaticMultiLineTemplate.json
+++ b/features/sample/templates/json/StaticMultiLineTemplate.json
@@ -1,0 +1,8 @@
+{
+  "id": 42,
+  "category": {
+    "name": "pet"
+  },
+  "name": "tiger",
+  "status": "available"
+}

--- a/features/sample/templates/json/StaticSingleLineTemplate.json
+++ b/features/sample/templates/json/StaticSingleLineTemplate.json
@@ -1,0 +1,1 @@
+{"id":42,"category":{"name":"pet"},"name":"tiger","status":"available"}

--- a/features/sample/templates/xml/DynamicMultiLineTemplate.xml
+++ b/features/sample/templates/xml/DynamicMultiLineTemplate.xml
@@ -1,0 +1,8 @@
+<result>
+    <id>@{pet id 2}</id>
+    <category>
+        <name>@{category name 2}</name>
+    </category>
+    <name>@{}</name>
+    <status>${my pet status}</status>
+</result>

--- a/features/sample/templates/xml/DynamicMultiLineTemplate.xml
+++ b/features/sample/templates/xml/DynamicMultiLineTemplate.xml
@@ -3,6 +3,6 @@
     <category>
         <name>@{category name 2}</name>
     </category>
-    <name>@{}</name>
+    <name>!{}</name>
     <status>${my pet status}</status>
 </result>

--- a/features/sample/templates/xml/DynamicSingleLineTemplate.xml
+++ b/features/sample/templates/xml/DynamicSingleLineTemplate.xml
@@ -1,0 +1,1 @@
+<result><id>@{}</id><category><name>pet</name></category><name>@{pet name 1}</name><status>${my pet status}</status></result>

--- a/features/sample/templates/xml/DynamicSingleLineTemplate.xml
+++ b/features/sample/templates/xml/DynamicSingleLineTemplate.xml
@@ -1,1 +1,1 @@
-<result><id>@{}</id><category><name>pet</name></category><name>@{pet name 1}</name><status>${my pet status}</status></result>
+<result><id>!{}</id><category><name>pet</name></category><name>@{pet name 1}</name><status>${my pet status}</status></result>

--- a/features/sample/templates/xml/StaticMultiLineTemplate.xml
+++ b/features/sample/templates/xml/StaticMultiLineTemplate.xml
@@ -1,0 +1,8 @@
+<result>
+    <id>42</id>
+    <category>
+        <name>pet</name>
+    </category>
+    <name>tiger</name>
+    <status>available</status>
+</result>

--- a/features/sample/templates/xml/StaticSingleLineTemplate.xml
+++ b/features/sample/templates/xml/StaticSingleLineTemplate.xml
@@ -1,0 +1,1 @@
+<result><id>42</id><category><name>pet</name></category><name>tiger</name><status>available</status></result>

--- a/src/main/scala/gwen/Predefs.scala
+++ b/src/main/scala/gwen/Predefs.scala
@@ -32,7 +32,10 @@ import com.typesafe.scalalogging.LazyLogging
 import scala.concurrent.duration.Duration
 import java.text.DecimalFormat
 
+import gwen.dsl.Position
 import org.apache.commons.text.StringEscapeUtils
+
+import scala.io.Source
 
 /**
   * Predefined implicits.
@@ -246,6 +249,18 @@ object Predefs extends LazyLogging {
       if (durations.isEmpty) Duration.Zero
       else if (durations.size == 1) durations.head
       else durations.reduce(_+_)
+  }
+
+  object StringOps {
+    def lastPositionIn(source: String): Position = {
+      Source.fromString(s"$source ").getLines().toList match {
+        case Nil =>
+          Position(1, 1)
+        case lines =>
+          val lastLength = lines.last.length - 1
+          Position(if (lines.size > 0) lines.size else 1, if (lastLength > 0) lastLength else 1)
+      }
+    }
   }
   
 }

--- a/src/main/scala/gwen/errors.scala
+++ b/src/main/scala/gwen/errors.scala
@@ -64,7 +64,7 @@ package gwen {
     def dataTableError(msg: String) = throw new DataTableException(msg)
     def scriptError(language: String, script: String, cause: Throwable) = throw new ScriptException(language, script, cause)
     def javaScriptError(javascript: String, cause: Throwable) = throw new ScriptException("JavaScript", javascript, cause)
-    def templateMatchError(lineNo: Int, msg: String) = throw new TemplateMatchException(lineNo, msg)
+    def templateMatchError(msg: String) = throw new TemplateMatchException(msg)
 
     /** Base exception\. */
     class GwenException (msg: String, cause: Throwable = null) extends RuntimeException(msg, cause)
@@ -150,7 +150,7 @@ package gwen {
     class ScriptException(language: String, script: String, cause: Throwable) extends GwenException(s"Failed to execute $language: ${if (language == "JavaScript" && script.startsWith("return ")) script.substring(7) else script}", cause)
 
     /** Thrown when a template match error is detected. */
-    class TemplateMatchException(lineNo: Int, msg: String) extends GwenException(s"Match error at template line $lineNo: $msg")
+    class TemplateMatchException(msg: String) extends GwenException(msg)
 
   }
 }

--- a/src/main/scala/gwen/errors.scala
+++ b/src/main/scala/gwen/errors.scala
@@ -64,6 +64,7 @@ package gwen {
     def dataTableError(msg: String) = throw new DataTableException(msg)
     def scriptError(language: String, script: String, cause: Throwable) = throw new ScriptException(language, script, cause)
     def javaScriptError(javascript: String, cause: Throwable) = throw new ScriptException("JavaScript", javascript, cause)
+    def templateMatchError(lineNo: Int, msg: String) = throw new TemplateMatchException(lineNo, msg)
 
     /** Base exception\. */
     class GwenException (msg: String, cause: Throwable = null) extends RuntimeException(msg, cause)
@@ -147,6 +148,9 @@ package gwen {
 
     /** Thrown when a script evaluation error is detected. */
     class ScriptException(language: String, script: String, cause: Throwable) extends GwenException(s"Failed to execute $language: ${if (language == "JavaScript" && script.startsWith("return ")) script.substring(7) else script}", cause)
+
+    /** Thrown when a template match error is detected. */
+    class TemplateMatchException(lineNo: Int, msg: String) extends GwenException(s"Match error at template line $lineNo: $msg")
 
   }
 }

--- a/src/main/scala/gwen/eval/EnvContext.scala
+++ b/src/main/scala/gwen/eval/EnvContext.scala
@@ -348,35 +348,38 @@ class EnvContext(options: GwenOptions, scopes: ScopedDataStack) extends Evaluata
       case "match json path" => !evaluateJsonPath(expected, actual).isEmpty
       case "match template" | "match template file" =>
         val template = expected
-        val pattern = Regex.quote(template).replaceAll("""@\{.*?\}""", """\\E(.*?)\\Q""").replaceAll("""\\Q\\E""", "")
-        if (actual.matches(pattern)) {
-          val names = """@\{.*?\}""".r.findAllIn(template).toList.zipWithIndex map { case (n, i) =>
-            if (n == "&{}") s"&[$i]" else n
+        val templateLines = Source.fromString(template).getLines().toList
+        val actualLines = Source.fromString(actual).getLines().toList
+        if (templateLines.size != actualLines.size && !negate) {
+          val lineCount = templateLines.size
+          templateMatchError(lineCount, s"Template has $lineCount line${if (lineCount != 1) "s" else ""} but got ${actualLines.size} in source: $actual" )
+        }
+        val names = """@\{.*?\}""".r.findAllIn(template).toList.zipWithIndex map { case (n, i) =>
+          if (n == "&{}") s"&[$i]" else n
+        }
+        names.groupBy(identity).collectFirst { case (n, vs) if vs.size > 1 =>
+          ambiguousCaseError(s"$n parameter defined ${vs.size} times in template '$template'")
+        }
+        val lines = templateLines zip actualLines
+        val values = (lines map { case (tLine, aLine) =>
+          (Regex.quote(tLine).replaceAll("""@\{.*?\}""", """\\E(.*?)\\Q""").replaceAll("""\\Q\\E""", ""), aLine)
+        }).filter(_._1.contains("(.*?)")).zipWithIndex.flatMap { case ((tLine, aLine), lineIdx) =>
+          if (!aLine.matches(tLine) && !negate) {
+             templateMatchError(lineIdx + 1, s"Expected match but got: $aLine")
           }
-          names.groupBy(identity).collectFirst { case (n, vs) if vs.size > 1 =>
-            ambiguousCaseError(s"$n parameter defined ${vs.size} times in template '$template'")
+          tLine.r.unapplySeq(aLine).get
+        }
+        val params = names zip values
+        val resolved = params.foldLeft(template) { (result, param) =>
+          val (n, v) = param
+          if (n.matches("""@\[\d+\]""")) result.replaceFirst("""@\{\}""", v)
+          else result.replace(n, v)
+        }
+        actual == resolved tap { isMatch =>
+          if (isMatch) {
+            params.filter { case (n, _) => n.matches("""@\{.*?\}""") } foreach { case (n, v) =>
+              scopes.featureScope.set(n.substring(2, n.length-1), v) }
           }
-          val lines = Source.fromString(template).getLines().toList zip Source.fromString(actual).getLines().toList
-
-          val values = (lines map { case (tLine, aLine) =>
-            (Regex.quote(tLine).replaceAll("""@\{.*?\}""", """\\E(.*?)\\Q""").replaceAll("""\\Q\\E""", ""), aLine)
-          }).filter(_._1.contains("(.*?)")).flatMap { case (tLine, aLine) =>
-            tLine.r.unapplySeq(aLine).get
-          }
-          val params = names zip values
-          val resolved = params.foldLeft(template) { (result, param) =>
-            val (n, v) = param
-            if (n.matches("""@\[\d+\]""")) result.replaceFirst("""@\{\}""", v)
-            else result.replace(n, v)
-          }
-          actual == resolved tap { isMatch =>
-            if (isMatch) {
-              params.filter { case (n, _) => n.matches("""@\{.*?\}""") } foreach { case (n, v) =>
-                scopes.featureScope.set(n.substring(2, n.length-1), v) }
-            }
-          }
-        } else {
-          false
         }
     }
     if (!negate) res else !res

--- a/src/main/scala/gwen/eval/support/TemplateSupport.scala
+++ b/src/main/scala/gwen/eval/support/TemplateSupport.scala
@@ -44,7 +44,7 @@ trait TemplateSupport {
   def matchTemplate(template: String, source: String, sourceName: String): Try[Boolean] = Try {
     val names = """@\{.+?\}|!\{\}""".r.findAllIn(template).toList.zipWithIndex map { case (n, i) =>
       if (n == "!{}") s"![$i]" else n
-    } map (_.trim) filter (_ != "")
+    }
     names.groupBy(identity).collectFirst { case (n, vs) if vs.size > 1 =>
       templateMatchError(s"$n parameter defined ${vs.size} times in template '$template'")
     }
@@ -53,7 +53,7 @@ trait TemplateSupport {
     val lines = tLines zip Source.fromString(source).getLines().toList
 
     val values = (lines.zipWithIndex.filter(_._1._1.matches(""".*(@\{.*?\}|!\{.*?\}).*""")) map { case ((ttLine, aLine), idx) =>
-      (Regex.quote(ttLine).replaceAll("""@\{\}""", """\{@\}""").replaceAll("""@\{.*?\}|!\{\}""", """\\E(.*?)\\Q""").replaceAll("""\\Q\\E""", "").replaceAll("""!\{.+?\}""", """\{!\}"""), aLine, idx)
+      (Regex.quote(ttLine).replaceAll("""@\{\s*\}""", """\{@\}""").replaceAll("""@\{.*?\}|!\{\}""", """\\E(.*?)\\Q""").replaceAll("""\\Q\\E""", "").replaceAll("""!\{.+?\}""", """\{!\}"""), aLine, idx)
     }).flatMap { case (tLine, aLine, idx) =>
       tLine.r.unapplySeq(aLine).getOrElse {
         templateMatchError(s"Could not match '$aLine' at line ${idx + 1} in $sourceName to '${tLines(idx)}' in template (check literals and/or syntax)")

--- a/src/main/scala/gwen/eval/support/TemplateSupport.scala
+++ b/src/main/scala/gwen/eval/support/TemplateSupport.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2018 Branko Juric, Brady Wood
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gwen.eval.support
+
+import gwen.errors._
+import gwen.eval.{EnvContext, ScopedDataStack}
+import gwen.Predefs.{Kestrel, StringOps}
+import org.apache.commons.lang3.StringUtils
+
+import scala.io.Source
+import scala.util.Try
+import scala.util.matching.Regex
+
+/**
+  * Can be mixed into evaluation engines to provide template matching support. This will allow users to match any
+  * source content with a target template and also extract (@{name}), ignore (!{}), and inject (${name}) attributes
+  * in scope.
+  */
+trait TemplateSupport {
+  this: EnvContext =>
+
+  /**
+    * Matches a template against a given source and extracts, ignores, or injects values.
+    * 
+    * @param template the template string
+    * @param source the source string
+    * @param sourceName the name of the source attribute
+    * @return success if there is a match; an error otherwise
+    */
+  def matchTemplate(template: String, source: String, sourceName: String): Try[Boolean] = Try {
+    val names = """@\{.+?\}|!\{\}""".r.findAllIn(template).toList.zipWithIndex map { case (n, i) =>
+      if (n == "!{}") s"![$i]" else n
+    } map (_.trim) filter (_ != "")
+    names.groupBy(identity).collectFirst { case (n, vs) if vs.size > 1 =>
+      templateMatchError(s"$n parameter defined ${vs.size} times in template '$template'")
+    }
+
+    val tLines = Source.fromString(template).getLines().toList
+    val lines = tLines zip Source.fromString(source).getLines().toList
+
+    val values = (lines.zipWithIndex.filter(_._1._1.matches(""".*(@\{.*?\}|!\{.*?\}).*""")) map { case ((ttLine, aLine), idx) =>
+      (Regex.quote(ttLine).replaceAll("""@\{\}""", """\{@\}""").replaceAll("""@\{.*?\}|!\{\}""", """\\E(.*?)\\Q""").replaceAll("""\\Q\\E""", "").replaceAll("""!\{.+?\}""", """\{!\}"""), aLine, idx)
+    }).flatMap { case (tLine, aLine, idx) =>
+      tLine.r.unapplySeq(aLine).getOrElse {
+        templateMatchError(s"Could not match '$aLine' at line ${idx + 1} in $sourceName to '${tLines(idx)}' in template (check literals and/or syntax)")
+      }
+    }
+    val params = names zip values
+    val resolved = params.foldLeft(template) { (result, param) =>
+      val (n, v) = param
+      if (n.matches("""!\[\d+\]""")) result.replaceFirst("""!\{\}""", v)
+      else result.replace(n, v)
+    }
+    source == resolved tap { isMatch =>
+      if (isMatch) {
+        params.filter { case (n, _) => n.matches("""@\{.+?\}""") } foreach { case (n, v) =>
+          activeScope.featureScope.set(n.substring(2, n.length-1), v) }
+      } else {
+        val commonPrefix = StringUtils.getCommonPrefix(source, resolved)
+        val diffPos = StringOps.lastPositionIn(source.substring(0, commonPrefix.length + 1))
+        val diffChar = source.charAt(commonPrefix.length)
+        val diffLine = s"${Source.fromString(commonPrefix).getLines().toList.last}[$diffChar].."
+        templateMatchError(s"Expected '${resolved.charAt(commonPrefix.length)}' but got '$diffChar' at line ${diffPos.line} position ${diffPos.column} in $sourceName: '$diffLine'")
+      }
+    }
+  }
+
+    
+}

--- a/src/test/scala/gwen/StringOpsTest.scala
+++ b/src/test/scala/gwen/StringOpsTest.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018 Branko Juric, Brady Wood
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gwen
+
+import gwen.Predefs.StringOps.lastPositionIn
+import gwen.dsl.Position
+import org.scalatest.{FlatSpec, Matchers}
+
+class StringOpsTest extends FlatSpec with Matchers {
+
+  "empty string" should " return (1, 1)" in {
+    lastPositionIn("") should be (Position(1, 1))
+  }
+
+  "empty line" should " return (2, 1)" in {
+    lastPositionIn(
+      """
+        |""".stripMargin) should be (Position(2, 1))
+  }
+
+  "single character" should " return (1, 1)" in {
+    lastPositionIn("x") should be (Position(1, 1))
+  }
+
+  "single character line" should " return (2, 1)" in {
+    lastPositionIn(
+      """x
+        |""".stripMargin) should be (Position(2, 1))
+  }
+
+  "multi-character single line" should " return (1, 5)" in {
+    lastPositionIn("howdy") should be (Position(1, 5))
+  }
+
+  "multi-character single line followed by new line" should " return (2, 1)" in {
+    lastPositionIn(
+      """howdy
+        |""".stripMargin) should be (Position(2, 1))
+  }
+
+  "multiline non-empty last line" should " return last position" in {
+    lastPositionIn(
+      """First line
+        |Second line""".stripMargin) should be (Position(2, 11))
+  }
+
+  "multiline empty last line" should " return last position" in {
+    lastPositionIn(
+      """First line
+        |Second line
+        |""".stripMargin) should be (Position(3, 1))
+  }
+
+}

--- a/src/test/scala/gwen/eval/support/TemplateSupportTest.scala
+++ b/src/test/scala/gwen/eval/support/TemplateSupportTest.scala
@@ -59,6 +59,20 @@ class TemplateSupportTest extends FlatSpec with Matchers {
     }
   }
 
+  """Single line template""" should "fail when extract tag contains only whitespace" in {
+    val template = """{"id":@{   },"category":{"name":"pet"},"name":"tiger","status":"available"}"""
+    val source =   """{"id":43,"category":{"name":"pet"},"name":"tiger","status":"available"}"""
+
+    val result = templateSupport.matchTemplate(template, source, "my source")
+
+    result match {
+      case Success(_) =>
+        fail("Expected match to fail")
+      case Failure(err) =>
+        err.getMessage should be ("""Could not match '{"id":43,"category":{"name":"pet"},"name":"tiger","status":"available"}' at line 1 in my source to '{"id":@{   },"category":{"name":"pet"},"name":"tiger","status":"available"}' in template (check literals and/or syntax)""")
+    }
+  }
+
   """Single line template""" should "fail when ignore tag has a space" in {
     val template = """{"id":!{ },"category":{"name":"pet"},"name":"tiger","status":"available"}"""
     val source =   """{"id":43,"category":{"name":"pet"},"name":"tiger","status":"available"}"""
@@ -167,6 +181,34 @@ class TemplateSupportTest extends FlatSpec with Matchers {
         fail("Expected match to fail")
       case Failure(err) =>
         err.getMessage should be ("""Could not match '  "id": 43,' at line 2 in my source to '  "id": @{},' in template (check literals and/or syntax)""")
+    }
+  }
+
+  """Multi line template""" should "fail when extract tag contains only whitespace" in {
+    val template = """{
+                     |  "id": @{   },
+                     |  "category": {
+                     |    "name": "pet"
+                     |  },
+                     |  "name": "tiger",
+                     |  "status": "available"
+                     |}""".stripMargin
+    val source  = """{
+                     |  "id": 43,
+                     |  "category": {
+                     |    "name": "pet"
+                     |  },
+                     |  "name": "tiger",
+                     |  "status": "available"
+                     |}""".stripMargin
+
+    val result = templateSupport.matchTemplate(template, source, "my source")
+
+    result match {
+      case Success(_) =>
+        fail("Expected match to fail")
+      case Failure(err) =>
+        err.getMessage should be ("""Could not match '  "id": 43,' at line 2 in my source to '  "id": @{   },' in template (check literals and/or syntax)""")
     }
   }
 

--- a/src/test/scala/gwen/eval/support/TemplateSupportTest.scala
+++ b/src/test/scala/gwen/eval/support/TemplateSupportTest.scala
@@ -1,0 +1,257 @@
+/*
+ * Copyright 2018 Branko Juric, Brady Wood
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gwen.eval.support
+
+import gwen.eval.{EnvContext, GwenOptions, ScopedDataStack}
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.util.{Failure, Success}
+
+class TemplateSupportTest extends FlatSpec with Matchers {
+
+  val templateSupport: TemplateSupport = new EnvContext(GwenOptions(), new ScopedDataStack())
+
+  """Single line static template""" should "match" in {
+    val template = """{"id":42,"category":{"name":"pet"},"name":"tiger","status":"available"}"""
+    val source = template
+    templateSupport.matchTemplate(template, source, "my source").isSuccess should be (true)
+  }
+
+  """Single line static template""" should "not match when source is different" in {
+    val template = """{"id":42,"category":{"name":"pet"},"name":"tiger","status":"available"}"""
+    val source =   """{"id":43,"category":{"name":"pet"},"name":"tiger","status":"available"}"""
+
+    val result = templateSupport.matchTemplate(template, source, "my source")
+
+    result match {
+      case Success(_) =>
+        fail("Expected match to fail")
+      case Failure(err) =>
+        err.getMessage should be ("""Expected '2' but got '3' at line 1 position 8 in my source: '{"id":4[3]..'""")
+    }
+  }
+
+  """Single line template""" should "fail when extract tag is empty" in {
+    val template = """{"id":@{},"category":{"name":"pet"},"name":"tiger","status":"available"}"""
+    val source =   """{"id":43,"category":{"name":"pet"},"name":"tiger","status":"available"}"""
+
+    val result = templateSupport.matchTemplate(template, source, "my source")
+
+    result match {
+      case Success(_) =>
+        fail("Expected match to fail")
+      case Failure(err) =>
+        err.getMessage should be ("""Could not match '{"id":43,"category":{"name":"pet"},"name":"tiger","status":"available"}' at line 1 in my source to '{"id":@{},"category":{"name":"pet"},"name":"tiger","status":"available"}' in template (check literals and/or syntax)""")
+    }
+  }
+
+  """Single line template""" should "fail when ignore tag has a space" in {
+    val template = """{"id":!{ },"category":{"name":"pet"},"name":"tiger","status":"available"}"""
+    val source =   """{"id":43,"category":{"name":"pet"},"name":"tiger","status":"available"}"""
+
+    val result = templateSupport.matchTemplate(template, source, "my source")
+
+    result match {
+      case Success(_) =>
+        fail("Expected match to fail")
+      case Failure(err) =>
+        err.getMessage should be ("""Could not match '{"id":43,"category":{"name":"pet"},"name":"tiger","status":"available"}' at line 1 in my source to '{"id":!{ },"category":{"name":"pet"},"name":"tiger","status":"available"}' in template (check literals and/or syntax)""")
+    }
+  }
+
+  """Single line template""" should "fail when ignore tag is non empty" in {
+    val template = """{"id":!{nope},"category":{"name":"pet"},"name":"tiger","status":"available"}"""
+    val source =   """{"id":43,"category":{"name":"pet"},"name":"tiger","status":"available"}"""
+
+    val result = templateSupport.matchTemplate(template, source, "my source")
+
+    result match {
+      case Success(_) =>
+        fail("Expected match to fail")
+      case Failure(err) =>
+        err.getMessage should be ("""Could not match '{"id":43,"category":{"name":"pet"},"name":"tiger","status":"available"}' at line 1 in my source to '{"id":!{nope},"category":{"name":"pet"},"name":"tiger","status":"available"}' in template (check literals and/or syntax)""")
+    }
+  }
+
+  """Single line template""" should "fail when source does not match" in {
+    val template = """{"id":!{},"category":{"name":"pet"},"name":"tiger","state":"available"}"""
+    val source =   """{"id":42,"category":{"name":"pet"},"name":"tiger","status":"available"}"""
+
+    val result = templateSupport.matchTemplate(template, source, "my source")
+
+    result match {
+      case Success(_) =>
+        fail("Expected match to fail")
+      case Failure(err) =>
+        err.getMessage should be ("""Could not match '{"id":42,"category":{"name":"pet"},"name":"tiger","status":"available"}' at line 1 in my source to '{"id":!{},"category":{"name":"pet"},"name":"tiger","state":"available"}' in template (check literals and/or syntax)""")
+    }
+  }
+
+  """Multi line static template""" should "match" in {
+    val template = """{
+                     |  "id": 42,
+                     |  "category": {
+                     |    "name": "pet"
+                     |  },
+                     |  "name": "tiger",
+                     |  "status": "available"
+                     |}""".stripMargin
+    val source = template
+    templateSupport.matchTemplate(template, source, "my source").get should be (true)
+  }
+
+  """Multi line static template""" should "not match when source is different" in {
+    val template = """{
+                     |  "id": 42,
+                     |  "category": {
+                     |    "name": "pet"
+                     |  },
+                     |  "name": "tiger",
+                     |  "status": "available"
+                     |}""".stripMargin
+    val source  = """{
+                     |  "id": 43,
+                     |  "category": {
+                     |    "name": "pet"
+                     |  },
+                     |  "name": "tiger",
+                     |  "status": "available"
+                     |}""".stripMargin
+
+    val result = templateSupport.matchTemplate(template, source, "my source")
+
+    result match {
+      case Success(_) =>
+        fail("Expected match to fail")
+      case Failure(err) =>
+        err.getMessage should be ("""Expected '2' but got '3' at line 2 position 10 in my source: '  "id": 4[3]..'""")
+    }
+  }
+
+  """Multi line template""" should "fail when extract tag is empty" in {
+    val template = """{
+                     |  "id": @{},
+                     |  "category": {
+                     |    "name": "pet"
+                     |  },
+                     |  "name": "tiger",
+                     |  "status": "available"
+                     |}""".stripMargin
+    val source  = """{
+                     |  "id": 43,
+                     |  "category": {
+                     |    "name": "pet"
+                     |  },
+                     |  "name": "tiger",
+                     |  "status": "available"
+                     |}""".stripMargin
+
+    val result = templateSupport.matchTemplate(template, source, "my source")
+
+    result match {
+      case Success(_) =>
+        fail("Expected match to fail")
+      case Failure(err) =>
+        err.getMessage should be ("""Could not match '  "id": 43,' at line 2 in my source to '  "id": @{},' in template (check literals and/or syntax)""")
+    }
+  }
+
+  """Multi line template""" should "fail when ignore tag has a space" in {
+    val template = """{
+                     |  "id": !{ },
+                     |  "category": {
+                     |    "name": "pet"
+                     |  },
+                     |  "name": "tiger",
+                     |  "status": "available"
+                     |}""".stripMargin
+    val source  = """{
+                     |  "id": 43,
+                     |  "category": {
+                     |    "name": "pet"
+                     |  },
+                     |  "name": "tiger",
+                     |  "status": "available"
+                     |}""".stripMargin
+
+    val result = templateSupport.matchTemplate(template, source, "my source")
+
+    result match {
+      case Success(_) =>
+        fail("Expected match to fail")
+      case Failure(err) =>
+        err.getMessage should be ("""Could not match '  "id": 43,' at line 2 in my source to '  "id": !{ },' in template (check literals and/or syntax)""")
+    }
+  }
+
+  """Multi line template""" should "fail when ignore tag is non empty" in {
+    val template = """{
+                     |  "id": !{nope},
+                     |  "category": {
+                     |    "name": "pet"
+                     |  },
+                     |  "name": "tiger",
+                     |  "status": "available"
+                     |}""".stripMargin
+    val source  = """{
+                     |  "id": 43,
+                     |  "category": {
+                     |    "name": "pet"
+                     |  },
+                     |  "name": "tiger",
+                     |  "status": "available"
+                     |}""".stripMargin
+
+    val result = templateSupport.matchTemplate(template, source, "my source")
+
+    result match {
+      case Success(_) =>
+        fail("Expected match to fail")
+      case Failure(err) =>
+        err.getMessage should be ("""Could not match '  "id": 43,' at line 2 in my source to '  "id": !{nope},' in template (check literals and/or syntax)""")
+    }
+  }
+
+  """Multi line template""" should "fail when source does not match" in {
+    val template = """{
+                     |  "id": !{},
+                     |  "category": {
+                     |    "name": "pet"
+                     |  },
+                     |  "name": "tiger",
+                     |  "status": "available"
+                     |}""".stripMargin
+    val source  = """{
+                     |  "id": 42,
+                     |  "category": {
+                     |    "name": "pet"
+                     |  },
+                     |  "name": "tiger",
+                     |  "state": "available"
+                     |}""".stripMargin
+
+    val result = templateSupport.matchTemplate(template, source, "my source")
+
+    result match {
+      case Success(_) =>
+        fail("Expected match to fail")
+      case Failure(err) =>
+        err.getMessage should be ("""Expected 'u' but got 'e' at line 7 position 8 in my source: '  "stat[e]..'""")
+    }
+  }
+  
+}

--- a/src/test/scala/gwen/sample/templates/TemplatesInterpreterTest.scala
+++ b/src/test/scala/gwen/sample/templates/TemplatesInterpreterTest.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2017 Branko Juric, Brady Wood
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gwen.sample.templates
+
+import gwen.dsl.Failed
+import gwen.dsl.Passed
+import gwen.eval.GwenOptions
+import java.io.File
+
+import org.scalatest.FlatSpec
+import gwen.eval.GwenLauncher
+import gwen.report.ReportFormat
+import gwen.eval.ScopedDataStack
+import gwen.eval.EnvContext
+import gwen.eval.GwenInterpreter
+import gwen.eval.GwenApp
+import gwen.eval.support.DefaultEngineSupport
+
+class TemplatesEnvContext(val options: GwenOptions, val scopes: ScopedDataStack)
+  extends EnvContext(options, scopes) {
+  override def dsl: List[String] = Nil
+}
+
+trait TemplatesEvalEngine extends DefaultEngineSupport[TemplatesEnvContext] {
+  override def init(options: GwenOptions, scopes: ScopedDataStack): TemplatesEnvContext = new TemplatesEnvContext(options, scopes)
+}
+
+class TemplatesInterpreter
+  extends GwenInterpreter[TemplatesEnvContext]
+  with TemplatesEvalEngine
+
+object TemplatesInterpreter
+  extends GwenApp(new TemplatesInterpreter)
+
+class TemplatesInterpreterTest extends FlatSpec {
+  
+  "Templates" should "evaluate without error" in {
+    
+    val options = GwenOptions(
+      batch = true,
+      reportDir = Some(new File("target/report/templates")),
+      reportFormats = List(ReportFormat.html, ReportFormat.junit, ReportFormat.json),
+      features = List(new File("features/sample/templates"))
+    )
+      
+    val launcher = new GwenLauncher(new TemplatesInterpreter())
+    launcher.run(options, None) match {
+      case Passed(_) => // excellent :)
+      case Failed(_, error) => error.printStackTrace(); fail(error.getMessage)
+      case _ => fail("evaluation expected but got noop")
+    }
+  }
+  
+  "Templates" should "pass --dry-run test" in {
+    
+    val options = GwenOptions(
+      batch = true,
+      reportDir = Some(new File("target/report/templates-dry-run")),
+      reportFormats = List(ReportFormat.html, ReportFormat.junit, ReportFormat.json),
+      features = List(new File("features/sample/templates")),
+      dryRun = true
+    )
+      
+    val launcher = new GwenLauncher(new TemplatesInterpreter())
+    launcher.run(options, None) match {
+      case Passed(_) => // excellent :)
+      case Failed(_, error) => error.printStackTrace(); fail(error.getMessage)
+      case _ => fail("evaluation expected but got noop")
+    }
+  }
+  
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,6 +1,6 @@
 enablePlugins(GitVersioning)
 
-git.baseVersion := "2.12.6"
+git.baseVersion := "2.13.0"
 
 git.useGitDescribe := true
 


### PR DESCRIPTION
# Template Matching

This PR introduces pattern matching capabilities to gwen. This will allow users to match any source content with a target template that can either be specified as a text literal or text stored in a file.  Supported also is the ability to extract, ignore, and inject attributes.

## Examples

The following examples assume that the following JSON value is bound to an attribute named `my value` in the currently available scope:
- `{"id":42,"category":{"name":"pet"},"name":"tiger","status":"available"}`

Templates can contain JSON, XML, HTML, or any type of text and can also have multiple lines. The examples below use single-line JSON only.

### Match

The following will successfully match `my value`:

```
Then my value should match template "{"id":42,"category":{"name":"pet"},"name":"tiger","status":"available"}"
```

Same as the above, but using a DocString:
```
Then my value should match template
     """
     {"id":42,"category":{"name":"pet"},"name":"tiger","status":"available"}
     """
```

Same as the above, but using a multi-line DocString:

Same as above, but assumes template is in a file relative to location where Gwen is invoked:
```
Then my value should match template file "path/to/Template.json"
```

### Match and Ignore

The following example will successfully match `my value` and:
- Ignore the `id` value where `!{}` appears
```
Then my value should match template
     """
     {"id":!{},"category":{"name":"pet"},"name":"tiger","status":"available"}
     """
```

### Match, Ignore, and Extract

The following example will successfully match `my value` and:
- Ignore the `id` value where `!{}` appears
- Extract the `tiger` value where `@{pet name}` appears and bind it to the attribute named `pet name` in the feature scope
```
Then my value should match template
     """
     {"id":!{},"category":{"name":"pet"},"name":"@{pet name}","status":"available"}
     """
```

Subsequent steps can access the extracted `pet name` attribute like any other Gwen binding. For example, the following checks it's value:
```
And pet name should be "tiger"
```

### Match, Ignore, Extract, and Inject

The following example will successfully match `my value` and:
- Ignore the `id` value where `!{}` appears
- Extract the `tiger` value where `@{pet name}` appears and bind it to the attribute named `pet name` in the feature scope
- Inject the value bound to the `my status` attribute into the template where `${my status}` appears.
```
Given my status is "available"
 Then my value should match template
      """
      {"id":!{},"category":{"name":"pet"},"name":"@{pet name}","status":"${my status}"}
      """
  And pet name should be "tiger"
```







