### PR TITLE
Introduce synchronized StepDef execution

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,7 +3,7 @@
 August 25, 2018
 - Introduced @Synchronized annotation for StepDefs to support synchronized execution of certain steps.
   StepDefs having this annotation will have their steps executed by a single feature thread at a time in the case
-  of parallel execution. This feature was requested through PR gwen-interpreter/gwen-web#63 raised by @Rahul9844.
+  of parallel execution. This feature was requested through PR gwen-interpreter/gwen-web#63 raised by @rkevin99.
 
 2.15.2
 ======

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+2.16.0
+======
+August 25, 2018
+- Introduced @Synchronized annotation for StepDefs to support synchronized execution of certain steps.
+  StepDefs having this annotation will have their steps executed by a single feature thread at a time in the case
+  of parallel execution. This feature was requested through PR gwen-interpreter/gwen-web#63 raised by @Rahul9844.
+
 2.15.2
 ======
 June 23, 2018

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ to capture automation bindings and allow you to compose step definitions in a de
 
 ### What's New?
 
+- [Synchronized StepDef execution](https://github.com/gwen-interpreter/gwen-web/wiki/Synchronized-StepDefs)
 - [Template matching](https://github.com/gwen-interpreter/gwen/wiki/Template-Matching)
 - [Gwen Workspaces](https://gweninterpreter.wordpress.com/2017/12/18/gwen-workspaces/)
 
@@ -142,6 +143,7 @@ The following users raised issues or requests that have been addressed:
 - [anshu781126](https://github.com/anshu781126)
 - [ketu4u2010](https://github.com/ketu4u2010)
 - [Rahul9844](https://github.com/Rahul9844)
+- [rkevin99](https://github.com/rkevin99)
 
 Credits
 -------

--- a/features/sample/sync/Sync.meta
+++ b/features/sample/sync/Sync.meta
@@ -1,0 +1,30 @@
+#
+# Copyright 2018 Branko Juric, Brady Wood
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+ Feature: Sync meta
+
+@Synchronized
+@StepDef
+Scenario: I assign then increment x
+    Given y is "${x}"
+      And z is "${y}"
+     Then z should be "${x}"
+      And a is defined by javascript "${x} + 1"
+      And x is "${a}"
+
+@StepDef
+Scenario: x should equal <expected>
+    Given x should be "$<expected>"

--- a/features/sample/sync/Sync1.feature
+++ b/features/sample/sync/Sync1.feature
@@ -1,0 +1,23 @@
+#
+# Copyright 2018 Branko Juric, Brady Wood
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+ 
+ Feature: Sync 1
+
+Scenario: Sync 1 test
+    Given x is "1"
+     When I assign then increment x
+      And x should equal 2
+  

--- a/features/sample/sync/Sync2.feature
+++ b/features/sample/sync/Sync2.feature
@@ -1,0 +1,23 @@
+#
+# Copyright 2018 Branko Juric, Brady Wood
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+ 
+ Feature: Sync 2
+
+Scenario: Sync 2 test
+    Given x is "2"
+     When I assign then increment x
+     And x should equal 3
+  

--- a/features/sample/sync/Sync3.feature
+++ b/features/sample/sync/Sync3.feature
@@ -1,0 +1,23 @@
+#
+# Copyright 2018 Branko Juric, Brady Wood
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+ 
+ Feature: Sync 3
+
+Scenario: Sync 3 test
+    Given x is "3"
+     When I assign then increment x
+     And x should equal 4
+  

--- a/features/sample/sync/Sync4.feature
+++ b/features/sample/sync/Sync4.feature
@@ -1,0 +1,23 @@
+#
+# Copyright 2018 Branko Juric, Brady Wood
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+ 
+ Feature: Sync 4
+
+Scenario: Sync 4 test
+    Given x is "4"
+     When I assign then increment x
+      And x should equal 5
+  

--- a/src/main/scala/gwen/dsl/GwenModel.scala
+++ b/src/main/scala/gwen/dsl/GwenModel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 Branko Juric, Brady Wood
+ * Copyright 2014-2018 Branko Juric, Brady Wood
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -207,6 +207,7 @@ case class Scenario(
   def isStepDef: Boolean = tags.contains(Tag.StepDefTag)
   def isForEach: Boolean = tags.contains(Tag.ForEachTag)
   def isDataTable: Boolean = tags.exists(_.name.startsWith(Tag.DataTableTag.name))
+  def isSynchronized: Boolean = tags.exists(t => t == Tag.SynchronizedTag || t == Tag.SynchronisedTag)
 
   def attachments: List[(String, File)] = allSteps.flatMap(_.attachments)
   
@@ -326,8 +327,10 @@ object Tag {
   val StepDefTag = Tag("StepDef")
   val ForEachTag = Tag("ForEach")
   val DataTableTag = Tag("DataTable")
+  val SynchronisedTag = Tag("Synchronised")
+  val SynchronizedTag = Tag("Synchronized")
 
-  val InbuiltTags = List(ImportTag, StepDefTag, ForEachTag, DataTableTag)
+  val InbuiltTags = List(ImportTag, StepDefTag, ForEachTag, DataTableTag, SynchronisedTag, SynchronizedTag)
 
   private val Regex = """~?@([^\s]+)""".r
 

--- a/src/main/scala/gwen/eval/EnvContext.scala
+++ b/src/main/scala/gwen/eval/EnvContext.scala
@@ -57,6 +57,9 @@ class EnvContext(options: GwenOptions, scopes: ScopedDataStack) extends Evaluata
   /** Dry run flag. */
   val isDryRun: Boolean = options.dryRun
 
+  /** Parallel execution mode flag. */
+  val isParallel: Boolean = options.parallel
+
   /** Current list of loaded meta (used to track and avoid duplicate meta loads). */
   var loadedMeta: List[File] = Nil
 

--- a/src/main/scala/gwen/eval/EvalEngine.scala
+++ b/src/main/scala/gwen/eval/EvalEngine.scala
@@ -69,7 +69,7 @@ trait EvalEngine[T <: EnvContext] extends LazyLogging {
       if (!scenario.isStepDef) dataTableError(s"${Tag.StepDefTag} tag also expected where ${Tag.DataTableTag} is specified")
       logger.info(s"Loading ${scenario.keyword}: ${scenario.name}")
       env.addStepDef(scenario)
-      if (scenario.isSynchronized) {
+      if (env.isParallel && scenario.isSynchronized) {
         stepDefSemaphors.putIfAbsent(scenario.name, new Semaphore(1))
       }
       val steps =
@@ -169,7 +169,7 @@ trait EvalEngine[T <: EnvContext] extends LazyLogging {
                   }
                 }
               case (Some((stepDef, params))) =>
-                if (stepDef.isSynchronized) {
+                if (stepDefSemaphors.containsKey(stepDef.name)) {
                   val semaphore = stepDefSemaphors.get(stepDef.name)
                   semaphore.acquire()
                   try {

--- a/src/test/scala/gwen/sample/sync/SyncInterpreterTest.scala
+++ b/src/test/scala/gwen/sample/sync/SyncInterpreterTest.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2018 Branko Juric, Brady Wood
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gwen.sample.sync
+
+import gwen.dsl.Failed
+import gwen.dsl.Passed
+import gwen.eval.GwenOptions
+import java.io.File
+
+import org.scalatest.FlatSpec
+import gwen.eval.GwenLauncher
+import gwen.report.ReportFormat
+import gwen.eval.ScopedDataStack
+import gwen.eval.EnvContext
+import gwen.eval.EvalEngine
+import gwen.eval.GwenInterpreter
+import gwen.eval.support.DefaultEngineSupport
+
+class SyncEnvContext(val options: GwenOptions, val scopes: ScopedDataStack)
+  extends EnvContext(options, scopes) {
+  override def dsl: List[String] = Nil
+}
+
+trait SyncEvalEngine extends EvalEngine[SyncEnvContext] with DefaultEngineSupport[SyncEnvContext] {
+  override def init(options: GwenOptions, scopes: ScopedDataStack): SyncEnvContext = new SyncEnvContext(options, scopes)
+}
+
+class SyncInterpreter
+  extends GwenInterpreter[SyncEnvContext]
+  with SyncEvalEngine
+
+class SyncInterpreterTest extends FlatSpec {
+  
+  "Synced StepDef" should "evaluate one feature at time in parallel execution mode" in {
+    
+    val options = GwenOptions(
+      batch = true,
+      parallel = true,
+      reportDir = Some(new File("target/report/sync")),
+      reportFormats = List(ReportFormat.html, ReportFormat.junit, ReportFormat.json),
+      features = List(new File("features/sample/sync"))
+    )
+      
+    val launcher = new GwenLauncher(new SyncInterpreter())
+    launcher.run(options, None) match {
+      case Passed(_) => // excellent :)
+      case Failed(_, error) => error.printStackTrace(); fail(error.getMessage)
+      case _ => fail("evaluation expected but got noop")
+    }
+  }
+  
+  "Synced StepDef" should "pass --dry-run test" in {
+    
+    val options = GwenOptions(
+      batch = true,
+      parallel = true,
+      reportDir = Some(new File("target/report/sync-dry-run")),
+      reportFormats = List(ReportFormat.html, ReportFormat.junit, ReportFormat.json),
+      features = List(new File("features/sample/sync")),
+      dryRun = true
+    )
+      
+    val launcher = new GwenLauncher(new SyncInterpreter())
+    launcher.run(options, None) match {
+      case Passed(_) => // excellent :)
+      case Failed(_, error) => error.printStackTrace(); fail(error.getMessage)
+      case _ => fail("evaluation expected but got noop")
+    }
+  }
+  
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,6 +1,6 @@
 enablePlugins(GitVersioning)
 
-git.baseVersion := "2.15.2"
+git.baseVersion := "2.16.0"
 
 git.useGitDescribe := true
 


### PR DESCRIPTION
This feature introduces a `@Synchronized` annotation for [StepDefs](/gwen-interpreter/gwen/wiki/Meta-Features#compostable-steps). All the steps in a `StepDef` with this annotation will run in a single feature thread when called by multiple features in the case of parallel execution. 

For example, the 3 steps in the following step definition would execute for one feature only at any one time when called by multiple features running in parallel.

```gherkin
@Synchronized
@StepDef
Scenario: I run in a single feature thread
    Given step 1
     When step 2
     Then step 3
```

The `@Synchronized` annotation is ignored when features are executed in serial (non parallel) mode.

---
_This feature was originally requested through PR gwen-interpreter/gwen-web#63 raised by @ @rkevin99 and implemented here using a different approach._