### PR TITLE
Soft assertions

### DIFF
--- a/src/main/scala/gwen/GwenSettings.scala
+++ b/src/main/scala/gwen/GwenSettings.scala
@@ -35,7 +35,7 @@ object GwenSettings {
   /**
     * Provides access to the `gwen.feature.failfast.exit` property setting used to exit all execution 
     * on first failure (default value is `false`). 
-    * Enabling this feature will exit exceution when the first failure is detected. 
+    * Enabling this feature will exit execution when the first failure is detected.
     */
   def `gwen.feature.failfast.exit`: Boolean = Settings.getOpt("gwen.feature.failfast.exit").getOrElse("false").toBoolean
   
@@ -88,5 +88,12 @@ object GwenSettings {
     * feature, forcing the user to control explicitly through the -i/--input command line option which CSV files to load.
     */
   def `gwen.auto.discover.data.csv`: Boolean = Settings.getOpt("gwen.auto.discover.data.csv").getOrElse("true").toBoolean
+
+  /**
+    * Provides access to the `gwen.assertions.soft` property setting used to enable soft assertions
+    * (default value is `false`).
+    * Enabling this feature will cause feature execution to continue if an assertion step fails.
+    */
+  def `gwen.assertions.soft`: Boolean = Settings.getOpt("gwen.assertions.soft").getOrElse("false").toBoolean
 
 }

--- a/src/main/scala/gwen/dsl/EvalStatus.scala
+++ b/src/main/scala/gwen/dsl/EvalStatus.scala
@@ -25,6 +25,7 @@ sealed trait EvalStatus {
   
   val status: StatusKeyword.Value
   val nanos: Long
+  val timestamp = new Date()
   
   /** Returns the duration in nanoseconds. */
   def duration: Duration = Duration.fromNanos(nanos)
@@ -34,6 +35,9 @@ sealed trait EvalStatus {
   
   /** Must be overriden to return an emoticon. */
   def emoticon: String
+
+  /** Optional error cause. */
+  def cause: Option[Throwable] = None
   
   override def toString: String =
     if (nanos > 0) {
@@ -56,13 +60,26 @@ case class Passed(nanos: Long) extends EvalStatus {
   * Defines a failed evaluation status.
   * 
   * @param nanos the duration in nanoseconds
-  * @param error the error message
+  * @param error the error
   */
 case class Failed(nanos: Long, error: Throwable) extends EvalStatus {
   val status = StatusKeyword.Failed
-  val timestamp = new Date()
   override def exitCode = 1
   override def emoticon = "[:(]"
+  override def cause = Option(error.getCause)
+}
+
+/**
+  * Defines a warning evaluation status.
+  *
+  * @param nanos the duration in nanoseconds
+  * @param error the warning
+  */
+case class Warning(nanos: Long, error: Throwable) extends EvalStatus {
+  val status = StatusKeyword.Warning
+  override def exitCode = 0
+  override def emoticon = "[:|]"
+  override def cause = Option(error.getCause)
 }
 
 /** Defines the skipped status. */
@@ -100,23 +117,37 @@ object EvalStatus {
     * 
     * @param statuses the list of evaluation statuses
     */
-  def apply(statuses: List[EvalStatus]): EvalStatus = {
+  def apply(statuses: List[EvalStatus]): EvalStatus = apply(statuses, ignoreWarnings = true)
+
+  /**
+    * Function for getting the effective evaluation status of a given list of statuses.
+    *
+    * @param statuses the list of evaluation statuses
+    * @param ignoreWarnings true to ignore warnings, false otherwise
+    */
+  def apply(statuses: List[EvalStatus], ignoreWarnings: Boolean): EvalStatus = {
     if (statuses.nonEmpty) {
       val duration = DurationOps.sum(statuses.map(_.duration))
       statuses.collectFirst { case failed @ Failed(_, _) => failed } match {
-        case Some(failed) => Failed(duration.toNanos, failed.error)  
+        case Some(failed) => Failed(duration.toNanos, failed.error)
         case None =>
-          if (statuses.forall(_ == Loaded)) {
-            Loaded
-          } else {
-            statuses.filter(_ != Loaded).lastOption match {
-              case Some(lastStatus) => lastStatus match {
-                case Passed(_) => Passed(duration.toNanos)
-                case Skipped => lastStatus
-                case _ => Pending
+          statuses.collectFirst { case warning @ Warning(_, _) => warning } match {
+            case Some(warning) =>
+              if (ignoreWarnings) Passed(duration.toNanos)
+              else Warning(duration.toNanos, warning.error)
+            case None =>
+              if (statuses.forall(_ == Loaded)) {
+                Loaded
+              } else {
+                statuses.filter(_ != Loaded).lastOption match {
+                  case Some(lastStatus) => lastStatus match {
+                    case Passed(_) => Passed(duration.toNanos)
+                    case Skipped => lastStatus
+                    case _ => Pending
+                  }
+                  case None => Pending
+                }
               }
-              case None => Pending
-            }
           }
       }
     } else Skipped
@@ -129,7 +160,16 @@ object EvalStatus {
     * @param status the status to check
     * @return true if the status is Passed or Failed, false otherwise
     */
-  def isEvaluated(status: StatusKeyword.Value): Boolean = status == StatusKeyword.Passed || status == StatusKeyword.Failed
+  def isEvaluated(status: StatusKeyword.Value): Boolean = status == StatusKeyword.Passed || isError(status)
+
+  /**
+    * Returns true if the given status is an error status. A status is considered an error if it is
+    * Failed or Warning
+    *
+    * @param status the status to check
+    * @return true if the status is Failed or Warning, false otherwise
+    */
+  def isError(status: StatusKeyword.Value): Boolean = status == StatusKeyword.Failed || status == StatusKeyword.Warning
   
 }
 
@@ -140,9 +180,9 @@ object EvalStatus {
   */
 object StatusKeyword extends Enumeration {
 
-  val Passed, Failed, Skipped, Pending, Loaded = Value
+  val Passed, Failed, Warning, Skipped, Pending, Loaded = Value
   
-  val reportables = List(Passed, Failed, Skipped, Pending)
+  val reportables = List(Passed, Failed, Warning, Skipped, Pending)
 
   /**
     * Groups counts by status.

--- a/src/main/scala/gwen/dsl/GwenModel.scala
+++ b/src/main/scala/gwen/dsl/GwenModel.scala
@@ -81,6 +81,9 @@ case class FeatureSpec(
 
   /** Gets all attachments. */
   def attachments: List[(String, File)] = steps.flatMap(_.attachments)
+
+  /** Gets the number of warnings. */
+  def noOfWarnings: Int = steps.flatMap(s => s.stepDef.map(_.steps).getOrElse(List(s))).count(_.evalStatus.status == StatusKeyword.Warning)
   
   /** Returns the evaluation status of this feature spec. */
   override lazy val evalStatus: EvalStatus = {
@@ -152,7 +155,7 @@ case class Background(name: String, description: List[String], steps: List[Step]
 
   /** Returns the evaluation status of this background. */
   override lazy val evalStatus: EvalStatus = EvalStatus(steps.map(_.evalStatus))
-  
+
   override def toString: String = name
   
 }
@@ -199,8 +202,7 @@ case class Scenario(
     else FeatureKeyword.`Scenario Outline`.toString
 
   /**
-    * Returns a list containing all the background steps (if any) followed by 
-    * all the scenario steps.
+    * Returns a list containing all steps.
     */
   def allSteps: List[Step] = background.map(_.steps).getOrElse(Nil) ++ (if (!isOutline) steps else examples.flatMap(_.allSteps))
   

--- a/src/main/scala/gwen/eval/EvalEngine.scala
+++ b/src/main/scala/gwen/eval/EvalEngine.scala
@@ -384,6 +384,8 @@ trait EvalEngine[T <: EnvContext] extends LazyLogging {
       logger.info(msg)
     case Failed(_, _) => 
       logger.error(msg)
+    case Warning(_, _) =>
+      logger.warn(msg)
     case _ => 
       logger.warn(msg)
   }

--- a/src/main/scala/gwen/eval/FeatureResult.scala
+++ b/src/main/scala/gwen/eval/FeatureResult.scala
@@ -63,6 +63,6 @@ class FeatureResult(
       else List(s.evalStatus)
     })
   private[eval] lazy val stepCounts = StatusKeyword.countsByStatus(spec.scenarios.flatMap(_.allSteps.map(_.evalStatus)))
-  override def toString: String = s"""[${formatDuration(duration)}] ${evalStatus.status} ${evalStatus.emoticon}, [${formatDuration(overhead)}] Overhead, [${formatDuration(elapsedTime)}] Elapsed, Started: $started, Finished: $finished""".stripMargin
+  override def toString: String = s"""[${formatDuration(duration)}] ${evalStatus.status}${if (spec.noOfWarnings > 0) s" with ${spec.noOfWarnings} warning${if (spec.noOfWarnings > 1) "s" else ""}" else ""} ${evalStatus.emoticon}, [${formatDuration(overhead)}] Overhead, [${formatDuration(elapsedTime)}] Elapsed, Started: $started, Finished: $finished""".stripMargin
 }
 

--- a/src/test/scala/gwen/dsl/EvalStatusTest.scala
+++ b/src/test/scala/gwen/dsl/EvalStatusTest.scala
@@ -79,6 +79,7 @@ Background: The tester
     featureSpec.steps foreach {
       _.evalStatus should be (Pending)
     }
+    featureSpec.noOfWarnings                           should be(0)
   
   }
   
@@ -115,7 +116,129 @@ Background: The tester
     featureSpec.scenarios(1).evalStatus                should be (Passed(12))
     featureSpec.scenarios(2).background                should be (None)    
     featureSpec.scenarios(2).evalStatus                should be (Loaded)
+    featureSpec.noOfWarnings                           should be(0)
   
+  }
+
+  "Feature" should "pass with warning when there is a warning in background" in {
+
+    // setup
+    val warning = new Exception(StatusKeyword.Warning.toString)
+    var featureSpec = normalise(parse(featureString).get, None, None)
+
+    featureSpec = FeatureSpec(
+      featureSpec.feature,
+      None,
+      featureSpec.scenarios map {scenario =>
+        Scenario(
+          scenario.tags,
+          scenario.name,
+          scenario.description,
+          scenario.background map { background =>
+            Background(background.name, background.description, background.steps map {step =>
+              Step(step.keyword, step.name, if (step.name.contains("should")) Warning(1, warning) else Passed(1))
+            })
+          },
+          scenario.steps map {step =>
+            Step(step.keyword, step.name, if (scenario.isStepDef) Loaded else Passed(1))
+          })
+      })
+
+    // assert
+
+    featureSpec.evalStatus                             should be (Passed(24))
+    featureSpec.scenarios(0).background.get.evalStatus should be (Passed(6))
+    featureSpec.scenarios(0).evalStatus                should be (Passed(12))
+    featureSpec.scenarios(1).background.get.evalStatus should be (Passed(6))
+    featureSpec.scenarios(1).evalStatus                should be (Passed(12))
+    featureSpec.scenarios(2).background                should be (None)
+    featureSpec.scenarios(2).evalStatus                should be (Loaded)
+    featureSpec.noOfWarnings                           should be(6)
+
+  }
+
+  "Feature" should "pass when there is a warning in each scenario" in {
+
+    // setup
+    val warning = new Exception(StatusKeyword.Warning.toString)
+    var featureSpec = normalise(parse(featureString).get, None, None)
+
+    featureSpec = FeatureSpec(
+      featureSpec.feature,
+      None,
+      featureSpec.scenarios map {scenario =>
+        Scenario(
+          scenario.tags,
+          scenario.name,
+          scenario.description,
+          scenario.background map { background =>
+            Background(background.name, background.description, background.steps map {step =>
+              Step(step.keyword, step.name, Passed(1))
+            })
+          },
+          scenario.steps.zipWithIndex map { case (step, index) =>
+            Step(step.keyword, step.name, if (scenario.isStepDef) Loaded else if (index == 0) Warning(1, warning) else  Passed(1))
+          })
+      })
+
+    // assert
+
+    featureSpec.evalStatus                             should be (Passed(24))
+    featureSpec.scenarios(0).background.get.evalStatus should be (Passed(6))
+    featureSpec.scenarios(0).evalStatus                should be (Passed(12))
+    featureSpec.scenarios(1).background.get.evalStatus should be (Passed(6))
+    featureSpec.scenarios(1).evalStatus                should be (Passed(12))
+    featureSpec.scenarios(2).background                should be (None)
+    featureSpec.scenarios(2).evalStatus                should be (Loaded)
+    featureSpec.noOfWarnings                           should be(2)
+
+  }
+
+  "Feature" should "pass when there is a warning in one scenario" in {
+
+    // setup
+    val warning = new Exception(StatusKeyword.Warning.toString)
+    var featureSpec = normalise(parse(featureString).get, None, None)
+
+    var setWarning = false
+
+    featureSpec = FeatureSpec(
+      featureSpec.feature,
+      None,
+      featureSpec.scenarios map {scenario =>
+        Scenario(
+          scenario.tags,
+          scenario.name,
+          scenario.description,
+          scenario.background map { background =>
+            Background(background.name, background.description, background.steps map {step =>
+              Step(step.keyword, step.name, Passed(1))
+            })
+          },
+          scenario.steps map { step =>
+            val status = if (scenario.isStepDef) {
+              Loaded
+            } else if(!setWarning) {
+              setWarning = true
+              Warning(1, warning)
+            } else {
+              Passed(1)
+            }
+            Step(step.keyword, step.name, status)
+          })
+      })
+
+    // assert
+
+    featureSpec.evalStatus                             should be (Passed(24))
+    featureSpec.scenarios(0).background.get.evalStatus should be (Passed(6))
+    featureSpec.scenarios(0).evalStatus                should be (Passed(12))
+    featureSpec.scenarios(1).background.get.evalStatus should be (Passed(6))
+    featureSpec.scenarios(1).evalStatus                should be (Passed(12))
+    featureSpec.scenarios(2).background                should be (None)
+    featureSpec.scenarios(2).evalStatus                should be (Loaded)
+    featureSpec.noOfWarnings                           should be(1)
+
   }
   
   "Scenario 1" should "fail when a background step in scenario 1 fails" in {
@@ -176,6 +299,8 @@ Background: The tester
           _.evalStatus should be (Pending)
         }
     }
+
+    featureSpec.noOfWarnings should be(0)
   
   }
   
@@ -237,6 +362,8 @@ Background: The tester
           _.evalStatus should be (Pending)
         }
     }
+
+    featureSpec.noOfWarnings should be(0)
   
   }
   
@@ -305,6 +432,8 @@ Background: The tester
           _.evalStatus should be (Pending)
         }
     }
+
+    featureSpec.noOfWarnings should be(0)
   
   }
   
@@ -362,13 +491,16 @@ Background: The tester
         _.evalStatus should be (Pending)
       }
     }
+
+    featureSpec.noOfWarnings should be(0)
   
   }
 
 
-  "isEvaluated on Passed and Failed" should "return true, false otherwise" in {
+  "isEvaluated on Passed, Failed, and Warning" should "return true, false otherwise" in {
     EvalStatus.isEvaluated(StatusKeyword.Passed) should be (true)
     EvalStatus.isEvaluated(StatusKeyword.Failed) should be (true)
+    EvalStatus.isEvaluated(StatusKeyword.Warning) should be (true)
     EvalStatus.isEvaluated(StatusKeyword.Skipped) should be (false)
     EvalStatus.isEvaluated(StatusKeyword.Pending) should be (false)
     EvalStatus.isEvaluated(StatusKeyword.Loaded) should be (false)

--- a/src/test/scala/gwen/eval/FeatureSummaryTest.scala
+++ b/src/test/scala/gwen/eval/FeatureSummaryTest.scala
@@ -50,9 +50,9 @@ class FeatureSummaryTest extends FlatSpec with Matchers {
     summary.stepCounts.size should be (0)
     val summaryLines = summary.toString.split("\\r?\\n");
     summaryLines.size should be (7)
-    summaryLines(0) should be ("0 features: Passed 0, Failed 0, Skipped 0, Pending 0")
-    summaryLines(1) should be ("0 scenarios: Passed 0, Failed 0, Skipped 0, Pending 0")
-    summaryLines(2) should be ("0 steps: Passed 0, Failed 0, Skipped 0, Pending 0")
+    summaryLines(0) should be ("0 features: Passed 0, Failed 0, Warning 0, Skipped 0, Pending 0")
+    summaryLines(1) should be ("0 scenarios: Passed 0, Failed 0, Warning 0, Skipped 0, Pending 0")
+    summaryLines(2) should be ("0 steps: Passed 0, Failed 0, Warning 0, Skipped 0, Pending 0")
     summaryLines(3) should be ("")
     summaryLines(4).contains("Passed") should be (true)
   }
@@ -102,9 +102,9 @@ class FeatureSummaryTest extends FlatSpec with Matchers {
     summary.stepCounts should equal (Map((StatusKeyword.Passed -> 3)))
     summaryLines = summary.toString.split("\\r?\\n");
     summaryLines.size should be (7)
-    summaryLines(0) should be ("1 feature: Passed 1, Failed 0, Skipped 0, Pending 0")
-    summaryLines(1) should be ("1 scenario: Passed 1, Failed 0, Skipped 0, Pending 0")
-    summaryLines(2) should be ("3 steps: Passed 3, Failed 0, Skipped 0, Pending 0")
+    summaryLines(0) should be ("1 feature: Passed 1, Failed 0, Warning 0, Skipped 0, Pending 0")
+    summaryLines(1) should be ("1 scenario: Passed 1, Failed 0, Warning 0, Skipped 0, Pending 0")
+    summaryLines(2) should be ("3 steps: Passed 3, Failed 0, Warning 0, Skipped 0, Pending 0")
     summaryLines(3) should be ("")
     summaryLines(4).contains("Passed") should be (true)
     
@@ -125,9 +125,9 @@ class FeatureSummaryTest extends FlatSpec with Matchers {
     summary.stepCounts should equal (Map((StatusKeyword.Passed -> 4), (StatusKeyword.Failed -> 1), (StatusKeyword.Skipped -> 1)))
     summaryLines = summary.toString.split("\\r?\\n");
     summaryLines.size should be (7)
-    summaryLines(0) should be ("2 features: Passed 1, Failed 1, Skipped 0, Pending 0")
-    summaryLines(1) should be ("2 scenarios: Passed 1, Failed 1, Skipped 0, Pending 0")
-    summaryLines(2) should be ("6 steps: Passed 4, Failed 1, Skipped 1, Pending 0")
+    summaryLines(0) should be ("2 features: Passed 1, Failed 1, Warning 0, Skipped 0, Pending 0")
+    summaryLines(1) should be ("2 scenarios: Passed 1, Failed 1, Warning 0, Skipped 0, Pending 0")
+    summaryLines(2) should be ("6 steps: Passed 4, Failed 1, Warning 0, Skipped 1, Pending 0")
     summaryLines(3) should be ("")
     summaryLines(4).contains("Failed") should be (true)
     
@@ -153,9 +153,9 @@ class FeatureSummaryTest extends FlatSpec with Matchers {
     summary.stepCounts should equal (Map((StatusKeyword.Passed -> 10), (StatusKeyword.Failed -> 1), (StatusKeyword.Skipped -> 1)))
     summaryLines = summary.toString.split("\\r?\\n");
     summaryLines.size should be (7)
-    summaryLines(0) should be ("3 features: Passed 2, Failed 1, Skipped 0, Pending 0")
-    summaryLines(1) should be ("4 scenarios: Passed 3, Failed 1, Skipped 0, Pending 0")
-    summaryLines(2) should be ("12 steps: Passed 10, Failed 1, Skipped 1, Pending 0")
+    summaryLines(0) should be ("3 features: Passed 2, Failed 1, Warning 0, Skipped 0, Pending 0")
+    summaryLines(1) should be ("4 scenarios: Passed 3, Failed 1, Warning 0, Skipped 0, Pending 0")
+    summaryLines(2) should be ("12 steps: Passed 10, Failed 1, Warning 0, Skipped 1, Pending 0")
     summaryLines(3) should be ("")
     summaryLines(4).contains("Failed") should be (true)
     
@@ -176,9 +176,9 @@ class FeatureSummaryTest extends FlatSpec with Matchers {
     summary.stepCounts should equal (Map((StatusKeyword.Passed -> 10), (StatusKeyword.Failed -> 1), (StatusKeyword.Skipped -> 4)))
     summaryLines = summary.toString.split("\\r?\\n");
     summaryLines.size should be (7)
-    summaryLines(0) should be ("4 features: Passed 2, Failed 1, Skipped 1, Pending 0")
-    summaryLines(1) should be ("5 scenarios: Passed 3, Failed 1, Skipped 1, Pending 0")
-    summaryLines(2) should be ("15 steps: Passed 10, Failed 1, Skipped 4, Pending 0")
+    summaryLines(0) should be ("4 features: Passed 2, Failed 1, Warning 0, Skipped 1, Pending 0")
+    summaryLines(1) should be ("5 scenarios: Passed 3, Failed 1, Warning 0, Skipped 1, Pending 0")
+    summaryLines(2) should be ("15 steps: Passed 10, Failed 1, Warning 0, Skipped 4, Pending 0")
     summaryLines(3) should be ("")
     summaryLines(4).contains("Failed") should be (true)
     
@@ -198,9 +198,9 @@ class FeatureSummaryTest extends FlatSpec with Matchers {
     summary.stepCounts should equal (Map((StatusKeyword.Passed -> 10), (StatusKeyword.Failed -> 1), (StatusKeyword.Skipped -> 4), (StatusKeyword.Pending -> 2)))
     summaryLines = summary.toString.split("\\r?\\n");
     summaryLines.size should be (7)
-    summaryLines(0) should be ("5 features: Passed 2, Failed 1, Skipped 1, Pending 1")
-    summaryLines(1) should be ("6 scenarios: Passed 3, Failed 1, Skipped 1, Pending 1")
-    summaryLines(2) should be ("17 steps: Passed 10, Failed 1, Skipped 4, Pending 2")
+    summaryLines(0) should be ("5 features: Passed 2, Failed 1, Warning 0, Skipped 1, Pending 1")
+    summaryLines(1) should be ("6 scenarios: Passed 3, Failed 1, Warning 0, Skipped 1, Pending 1")
+    summaryLines(2) should be ("17 steps: Passed 10, Failed 1, Warning 0, Skipped 4, Pending 2")
     summaryLines(3) should be ("")
     summaryLines(4).contains("Failed") should be (true)
     
@@ -240,9 +240,9 @@ class FeatureSummaryTest extends FlatSpec with Matchers {
     summary.stepCounts should equal (Map((StatusKeyword.Passed -> 21), (StatusKeyword.Failed -> 2), (StatusKeyword.Skipped -> 6), (StatusKeyword.Pending -> 2)))
     summaryLines = summary.toString.split("\\r?\\n");
     summaryLines.size should be (7)
-    summaryLines(0) should be ("6 features: Passed 2, Failed 2, Skipped 1, Pending 1")
-    summaryLines(1) should be ("11 scenarios: Passed 7, Failed 2, Skipped 1, Pending 1")
-    summaryLines(2) should be ("31 steps: Passed 21, Failed 2, Skipped 6, Pending 2")
+    summaryLines(0) should be ("6 features: Passed 2, Failed 2, Warning 0, Skipped 1, Pending 1")
+    summaryLines(1) should be ("11 scenarios: Passed 7, Failed 2, Warning 0, Skipped 1, Pending 1")
+    summaryLines(2) should be ("31 steps: Passed 21, Failed 2, Warning 0, Skipped 6, Pending 2")
     summaryLines(3) should be ("")
     summaryLines(4).contains("Failed") should be (true)
     


### PR DESCRIPTION
This PR introduces soft assertions through the following Gwen setting:
- `gwen.assertions.soft`
  - Determines whether or not failed assertions are treated as warnings that permit normal execution to continue instead of errors which otherwise halt normal execution.
    - true to enable
    - false to disable (default)

When enabled, any assertion errors are converted to warnings and execution continues to the next step that follows. So in effect, you get accumulated assertion warnings in the evaluated results instead of a failed result.

Example report with soft assertions enabled (showing 2 assertions converted to warnings):

<img width="604" alt="screen shot 2019-01-24 at 7 29 46 pm" src="https://user-images.githubusercontent.com/1369994/51664873-91d81800-200e-11e9-8f03-1ebc3dd5f493.png">
