### PR TITLE
Introduce declarative mode to disallow imperative steps in features

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+2.23.0
+======
+November 21, 2020
+- Introduce "declarative" mode for features to prevent the user of imperative 
+  steps in features. Controlled through mew Gwen setting
+  - `gwen.feature.mode=declarative|imperative` (imperative is default)
+
 2.22.2
 ======
 November 28, 2019

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ have to do all the programming work. It has an abstracted
 
 ### What's New?
 
+- [Declarative feature mode](https://github.com/gwen-interpreter/gwen/wiki/Runtime-Settings#gwenfeaturemode) to force all imperative steps to meta and promote cleaner features.
 - [State levels](https://github.com/gwen-interpreter/gwen/wiki/State-Levels) and [parallel execution](https://github.com/gwen-interpreter/gwen/wiki/Execution-Modes#parallel-scenario-execution) for scenarios in additon to features
 - Integated the latest [Gherkin parser](https://github.com/cucumber/cucumber/tree/master/gherkin/java) from Cucumber to support [example mapping](https://cucumber.io/blog/2015/12/08/example-mapping-introduction)
-- Hard, soft, and sustained [Assertion modes](https://github.com/gwen-interpreter/gwen/wiki/Assertion-Modes)
 
 Why Gwen?
 ---------
@@ -70,6 +70,7 @@ Key Features
 - [Template matching](https://github.com/gwen-interpreter/gwen/wiki/Template-Matching)
 - Hard, soft, and sustained [Assertion modes](https://github.com/gwen-interpreter/gwen/wiki/Assertion-Modes)
 - [Synchronized StepDef execution](https://github.com/gwen-interpreter/gwen/wiki/Synchronized-StepDefs)
+- Hard, soft, and sustained [Assertion modes](https://github.com/gwen-interpreter/gwen/wiki/Assertion-Modes)
 
 
 License

--- a/src/main/scala/gwen/GwenSettings.scala
+++ b/src/main/scala/gwen/GwenSettings.scala
@@ -17,6 +17,7 @@
 package gwen
 
 import gwen.dsl.AssertionMode
+import gwen.dsl.FeatureMode
 import gwen.dsl.StateLevel
 
 /**
@@ -110,5 +111,16 @@ object GwenSettings {
     */
   def `gwen.state.level`: StateLevel.Value =
     Settings.getOpt("gwen.state.level").map(_.toLowerCase).map(StateLevel.withName).getOrElse(StateLevel.feature)
+
+  /**
+    * Provides access to the `gwen.feature.mode` property setting used to determine whether the
+    * feature mode is declarative or imperative (default value is `imperative`). When declarative,
+    * the DSL steps defined in the Gwen engine cannot be used directly in features and must be 
+    * bound to step definitions defined in meta instead. This forces the user to write features 
+    * that are clean and free of automation concerns. When imperative, then DSL steps can be used 
+    * directly in features.
+    */
+    def `gwen.feature.mode`: FeatureMode.Value = 
+      Settings.getOpt("gwen.feature.mode").map(_.toLowerCase).map(FeatureMode.withName).getOrElse(FeatureMode.imperative)
 
 }

--- a/src/main/scala/gwen/dsl/Keywords.scala
+++ b/src/main/scala/gwen/dsl/Keywords.scala
@@ -60,3 +60,8 @@ object StateLevel extends Enumeration {
   val scenario, feature = Value
 }
 
+object FeatureMode extends Enumeration {
+  type Feature = Value
+  val declarative, imperative = Value
+}
+

--- a/src/main/scala/gwen/errors.scala
+++ b/src/main/scala/gwen/errors.scala
@@ -69,6 +69,8 @@ package gwen {
     def templateMatchError(msg: String) = throw new TemplateMatchException(msg)
     def unsupportedLocalSetting(name: String) = throw new UnsupportedLocalSettingException(name)
     def invalidSettingError(name: String, value: String, msg: String) = throw new InvalidSettingException(name, value, msg)
+    def imperativeStepError(step: Step) = throw new ImperativeStepException(step)
+    def imperativeStepDefError(stepDef: Scenario) = throw new ImperativeStepDefException(stepDef)
 
     /** Base exception\. */
     class GwenException (msg: String, cause: Throwable = null) extends RuntimeException(msg, cause)
@@ -167,6 +169,12 @@ package gwen {
 
     /** Thrown when an invalid setting is provided. */
     class InvalidSettingException(name: String, value: String, msg: String) extends GwenException(s"Invalid setting $name=$value: $msg")
+
+    /** Thrown when an imperative step is detected in a feature when declarative mode is enabled. */
+    class ImperativeStepException(step: Step) extends GwenException(s"Imperative step not permitted in feature at line ${step.pos.line} (move it to meta): $step")
+
+    /** Thrown when an imperative step defenition is detected in a feature when declarative mode is enabled. */
+    class ImperativeStepDefException(stepDef: Scenario) extends GwenException(s"StepDef declaration not permitted in feature at line ${stepDef.pos.line} (move it to meta): ${stepDef.name}")
 
   }
 }

--- a/src/main/scala/gwen/eval/LocalDataStack.scala
+++ b/src/main/scala/gwen/eval/LocalDataStack.scala
@@ -83,6 +83,9 @@ class LocalDataStack {
     */
   def containsScope(scope: String): Boolean = localData.exists(_.scope == scope)
   
+  /** Checks whether or not the local stack is empty. */
+  def isEmpty = localData.isEmpty
+
   /**
     * Returns a string representation of the entire attribute stack
     */

--- a/version.sbt
+++ b/version.sbt
@@ -1,6 +1,6 @@
 enablePlugins(GitVersioning)
 
-git.baseVersion := "2.22.2"
+git.baseVersion := "2.23.0"
 
 git.useGitDescribe := true
 


### PR DESCRIPTION
Declarative Features for cleaner Gherkin
----------------------------------------

There's been a lot of talk in the Gherkin community about how declarative features should not contain imperative steps and automation clutter. This PR adds a declarative mode setting to help enforce clean Gherkin style by reporting imperative steps in features as errors. 

To enable declarative mode. just set the following Gwen setting:

`gwen.feature.mode=declarative`

With this mode set, any attempt to use a Gwen DSL step directly in a feature file will be reported as an error and you will need to define a custom step and associated step definition instead.

To disable declarative mode (and enable imperative mode), just remove the setting or set it to the following:

`gwen.feature.mode=imperative` 

For backwards compatibility, imperative is currently the default mode. However, we may in future major versions change this to declarative instead.
