### PR TITLE
Introduce behavior rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ project/project/target/
 .settings/
 .idea/
 .metals/
+.vscode/
 .bloop/
 *.log
 /bin/

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,18 @@
+2.25.0
+======
+March 8, 2020
+- Introduce behavior rules setting to enforce good Gherkin style
+  - `gwen.behavior.rules=strict|lenient`
+    - `strict`: The following rules are enforced in feature files with violations reported as errors:
+      - Steps in scenarios and backgrounds must satisfy *Given-When-Then* order
+      - *Given* steps must set context
+      - *When* steps must perform actions
+      - *Then* steps must perform assertions
+      - *But* steps must perform assertions (and are permitted after *Then* steps)
+    - `lenient`: no rules are enforced
+    - Default is `lenient` for backwards compatiblity but plan is to change it 
+      to `strict` in upcoming major (v3.0.0) release
+
 2.24.0
 ======
 January 29, 2020

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ have to do all the programming work. It has an abstracted
 
 ### What's New?
 
+- [Behavior rules](https://github.com/gwen-interpreter/gwen/wiki/Runtime-Settings#gwenbehaviorrules) to help enforce good Gherkin style
 - [Associative meta](https://github.com/gwen-interpreter/gwen/wiki/Runtime-Settings#gwenassociativemeta)
 - [Declarative feature mode](https://github.com/gwen-interpreter/gwen/wiki/Runtime-Settings#gwenfeaturemode) to force all imperative steps to meta and promote cleaner features.
-- [State levels](https://github.com/gwen-interpreter/gwen/wiki/State-Levels) and [parallel execution](https://github.com/gwen-interpreter/gwen/wiki/Execution-Modes#parallel-scenario-execution) for scenarios in additon to features
 
 Why Gwen?
 ---------
@@ -72,6 +72,7 @@ Key Features
 - [Synchronized StepDef execution](https://github.com/gwen-interpreter/gwen/wiki/Synchronized-StepDefs)
 - Hard, soft, and sustained [Assertion modes](https://github.com/gwen-interpreter/gwen/wiki/Assertion-Modes)
 - Supports full Gherkin syntax including [example mapping](https://cucumber.io/blog/2015/12/08/example-mapping-introduction)
+- [State levels](https://github.com/gwen-interpreter/gwen/wiki/State-Levels) and [parallel execution](https://github.com/gwen-interpreter/gwen/wiki/Execution-Modes#parallel-scenario-execution) for scenarios in additon to features
 
 User Network and Support
 ------------------------

--- a/features/sample/bindings/Bindings.feature
+++ b/features/sample/bindings/Bindings.feature
@@ -1,5 +1,5 @@
 # 
-# Copyright 2016 Brady Wood, Branko Juric
+# Copyright 2016-2020 Brady Wood, Branko Juric
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,16 +15,14 @@
 #
 
    Feature: Binding tests
-
-Background: Init globals
-	    Given a1 is "${property.a}"
-	      And a2 is "${a1}"
-      
+	    
   Scenario: Check bindings
-      Given a1 should be "A"
-        And a2 should be "A"
+      Given a1 is "${property.a}"
+        And a2 is "${a1}"
        When I bind more properties
-       Then a3 should be "A"
+       Then a1 should be "A"
+        And a2 should be "A"
+        And a3 should be "A"
         And b1 should be "B"
         And b2 should be "B"
         And b3 should be "B"

--- a/features/sample/bindings/Bindings.meta
+++ b/features/sample/bindings/Bindings.meta
@@ -1,5 +1,5 @@
 # 
-# Copyright 2016 Brady Wood, Branko Juric
+# Copyright 2016-2020 Brady Wood, Branko Juric
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,9 +17,10 @@
  Feature: Meta bindings
       
 @StepDef
+@Action
 Scenario: I bind more properties
     Given a3 is "${a2}"
       And b1 is "${property.b}"
-     Then b2 is "${b1}"
+      And b2 is "${b1}"
       And b3 is "${b2}"
 	

--- a/features/sample/docStrings/DocStrings.feature
+++ b/features/sample/docStrings/DocStrings.feature
@@ -17,9 +17,11 @@
  Feature: DocStrings
 
    Scenario: Javascript DocString binding
-       Given the current date is formatted as yyyy-mm-dd
-        Then the current date should match regex "\d{4}-\d{2}-\d{2}"
-         And the current date should be "${the current date}"
+       Given the formatted date is ""
+        When the current date is formatted as yyyy-mm-dd
+        Then the formatted date should match regex "\d{4}-\d{2}-\d{2}"
+         And the formatted date should be "${the formatted date}"
+         But the formatted date should not be ""
 
    Scenario: Paragraph of text
        Given my paragraph is
@@ -30,7 +32,8 @@
              in Gherkin) are used to capture automation bindings and allow you to compose step definitions by mapping
              'declarative' steps in features to 'imperative' steps in engines that perform operations.
              """
-        Then my paragraph should be
+        When I capture my paragraph as contents
+        Then contents should be
              """
              Gwen is a Gherkin interpreter that turns Given-When-Then steps into automation instructions and executes
              them for you so you don't have to do all the programming work. It has an abstracted evaluation engine
@@ -44,7 +47,8 @@
              """
              Gwen is a Gherkin interpreter that turns Given-When-Then steps into automation instructions.
              """
-        Then my line should be
+        When I capture my line as contents
+        Then contents should be
              """
              Gwen is a Gherkin interpreter that turns Given-When-Then steps into automation instructions.
              """
@@ -63,7 +67,8 @@
              you to compose step definitions by mapping 'declarative' steps in features to 'imperative' steps in engines
              that perform operations.
              """
-        Then my paragraph should be
+        When I capture my paragraph as contents
+        Then contents should be
              """
              Gwen is a Gherkin interpreter that turns Given-When-Then steps into automation instructions and
              executes them for you so you don't have to do all the programming work. It has an abstracted evaluation
@@ -79,7 +84,8 @@
              """text
              Gwen is a Gherkin interpreter that turns Given-When-Then steps into automation instructions.
              """
-        Then my line should be
+        When I capture my line as contents
+        Then contents should be
              """text
              Gwen is a Gherkin interpreter that turns Given-When-Then steps into automation instructions.
              """

--- a/features/sample/docStrings/DocStrings.meta
+++ b/features/sample/docStrings/DocStrings.meta
@@ -17,8 +17,9 @@
  Feature: DocStrings Meta
 
    @StepDef
+   @Action
    Scenario: the current date is formatted as yyyy-mm-dd
-       Given the current date is defined by javascript
+       Given the formatted date is defined by javascript
              """JavaScript
              (function() {
                var d = new Date();

--- a/features/sample/math/Math.meta
+++ b/features/sample/math/Math.meta
@@ -17,12 +17,13 @@
  Feature: Math functions
 
 @StepDef
+@Action
 Scenario: ++x
-    Increments the value of x
     Given z = x + 1
      Then x = z
      
 @StepDef
+@Action
 Scenario: z = <x> + <y>
     Given x = $<x>
       And y = $<y>

--- a/features/sample/math/MetaMath.feature
+++ b/features/sample/math/MetaMath.feature
@@ -14,12 +14,8 @@
 # limitations under the License.
 #
  
- Feature: Increment integer
-          Uses stepdefs in meta to perform increment operations
-
-Background: Reset
-            Resets x to zero
-      Given x = 0
+ Feature: Integer math
+          Uses stepdefs in meta to perform integer math
             
 Scenario: Incrementing 0 should yield 1
     Given x = 0
@@ -27,7 +23,8 @@ Scenario: Incrementing 0 should yield 1
      Then x == 1
      
 Scenario: Addition with stepdef parameters
-    Given z = 1 + 2
+    Given z = 0
+     When z = 1 + 2
      Then z == 3
      
 Scenario: Addition using stepdef with leading parameter

--- a/features/sample/outlines/JoinStrings.feature
+++ b/features/sample/outlines/JoinStrings.feature
@@ -35,5 +35,7 @@
        | howdy    | doo      | howdydoo |
        | any      | thing    | anything |
 
-   Scenario: Verify that we can join two strings together
-       Given I join two strings together
+   Scenario: Verify that we can join two strings in meta
+      Given result is ""
+       When I join two strings in meta
+       Then the result should not be ""

--- a/features/sample/outlines/JoinStrings.meta
+++ b/features/sample/outlines/JoinStrings.meta
@@ -17,11 +17,13 @@
  Feature: Join Strings Meta
 
   @StepDef
+  @Action
   Scenario: I join the two strings
       Given the result is "${string 1}${string 2}"
 
   @StepDef
-  Scenario Outline: I join two strings together
+  @Action
+  Scenario Outline: I join two strings in meta
 
        This scenario is loaded into memory and evaluated whenever
        the outline is referenced by a step in a feature
@@ -30,7 +32,6 @@
         And string 2 is "<string 2>"
        When I join the two strings
        Then the result should be "<result>"
-        And I join the two strings
 
        Examples:
 

--- a/features/sample/rules/StringRules.feature
+++ b/features/sample/rules/StringRules.feature
@@ -21,7 +21,9 @@
       Background: Reset strings
             Given string 1 is ""
               And string 2 is ""
-              And the result is ""
+             When I join the two strings
+             Then the result should be ""
+
 
          Scenario Template: Joining <string 1> and <string 2> should yield <result>
 
@@ -41,8 +43,10 @@
                   | howdy    | doo      | howdydoo |
                   | any      | thing    | anything |
 
-         Example: Verify that we can join two strings together
-            Given I join two strings together
+         Example: Verify that we can join two strings in meta
+            Given the result is ""
+             When I join two strings in meta
+             Then the result should not be ""
 
     Rule: Replacing a substring in a string should result in substitution of the substring
 
@@ -50,7 +54,8 @@
             Given string 1 is ""
               And string 2 is ""
               And string 3 is ""
-              And the result is ""
+             When I substitute string 1 for string 2 in string 3
+             Then the result should be ""
 
          Scenario Template: Substituting <string 1> for <string 2> in <string 3> should yield <result>
 

--- a/features/sample/rules/StringRules.meta
+++ b/features/sample/rules/StringRules.meta
@@ -17,17 +17,18 @@
  Feature: Strings rules Meta
 
   @StepDef
+  @Action
   Scenario: I join the two strings
       Given the result is "${string 1}${string 2}"
 
-   @StepDef
-   Scenario Template: I join two strings together
+  @StepDef
+  @Action
+  Scenario Template: I join two strings in meta
 
       Given string 1 is "<string 1>"
         And string 2 is "<string 2>"
        When I join the two strings
        Then the result should be "<result>"
-        And I join the two strings
 
   Examples:
 
@@ -39,6 +40,7 @@
             | any      | thing    | anything |
 
   @StepDef
+  @Action
   Scenario: I substitute string 1 for string 2 in string 3
       Given the result is defined by javascript "'${string 3}'.replace('${string 1}', '${string 2}')"
       

--- a/features/sample/sync/Sync.meta
+++ b/features/sample/sync/Sync.meta
@@ -18,7 +18,8 @@
 
 @Synchronized
 @StepDef
-Scenario: I assign then increment x
+@Action
+Scenario: I increment x
     Given y is "${x}"
       And z is "${y}"
      Then z should be "${x}"
@@ -26,5 +27,6 @@ Scenario: I assign then increment x
       And x is "${a}"
 
 @StepDef
+@Assertion
 Scenario: x should equal <expected>
     Given x should be "$<expected>"

--- a/features/sample/sync/Sync1.feature
+++ b/features/sample/sync/Sync1.feature
@@ -18,6 +18,6 @@
 
 Scenario: Sync 1 test
     Given x is "1"
-     When I assign then increment x
-      And x should equal 2
+     When I increment x
+     Then x should equal 2
   

--- a/features/sample/sync/Sync2.feature
+++ b/features/sample/sync/Sync2.feature
@@ -18,6 +18,6 @@
 
 Scenario: Sync 2 test
     Given x is "2"
-     When I assign then increment x
-     And x should equal 3
+     When I increment x
+     Then x should equal 3
   

--- a/features/sample/sync/Sync3.feature
+++ b/features/sample/sync/Sync3.feature
@@ -18,6 +18,6 @@
 
 Scenario: Sync 3 test
     Given x is "3"
-     When I assign then increment x
-     And x should equal 4
+     When I increment x
+     Then x should equal 4
   

--- a/features/sample/sync/Sync4.feature
+++ b/features/sample/sync/Sync4.feature
@@ -18,6 +18,6 @@
 
 Scenario: Sync 4 test
     Given x is "4"
-     When I assign then increment x
-      And x should equal 5
+     When I increment x
+     Then x should equal 5
   

--- a/features/sample/tables/NumberTables.feature
+++ b/features/sample/tables/NumberTables.feature
@@ -16,75 +16,54 @@
 
  Feature: Number tables
 
-   Scenario: Single record horizontal data table with no header
+   Scenario: Various table forms
        Given single row without header contains a number in decimal and binary form
              | 3 | 11 |
-
-   Scenario: Single record horizontal data table with header
-       Given single row with header contains a number in decimal and binary form
+         And single row with header contains a number in decimal and binary form
              | decimal | binary |
              | 3       | 11     |
-
-   Scenario: Single record vertical data table with no header
-       Given single column without header contains a number in decimal and binary form
+         And single column without header contains a number in decimal and binary form
              | 3  |
              | 11 |
-
-   Scenario: Single record vertical data table with header
-       Given single column with header contains a number in decimal and binary form
+         And single column with header contains a number in decimal and binary form
              | decimal | 3  |
              | binary  | 11 |
-
-   Scenario: Horizontal table with header
-       Given each row contains a number and its square and cube
+         And each row contains a number and its square and cube
              | number | square | cube |
              | 1      | 1      | 1    |
              | 2      | 4      | 8    |
              | 3      | 9      | 27   |
-
-   Scenario: Horizontal data table with no header
-       Given each row contains a number in decimal and binary form
+         And each row contains a number in decimal and binary form
              | 1 | 1  |
              | 2 | 10 |
              | 3 | 11 |
-
-   Scenario: Vertical table with header
-       Given each column contains a number and its square and cube
+         And each column contains a number and its square and cube
              | number | 1 | 2 | 3  |
              | square | 1 | 4 | 9  |
              | cube   | 1 | 8 | 27 |
-
-   Scenario: Vertical data table with no header
-       Given each column contains a number in decimal and binary form
+         And each column contains a number in decimal and binary form
              | 4   | 5    | 6   |
              | 100 | 101  | 110 |
-
-   Scenario: Matrix table with top and left headers
-       Given the top and left numbers yield the product in the matrix
+         And the top and left numbers yield the product in the matrix
              | x | 1 | 2 | 3 |
              | 1 | 1 | 2 | 3 |
              | 2 | 2 | 4 | 6 |
              | 3 | 3 | 6 | 9 |
-
-   Scenario: Horizontal Fibonacci table with no header
-       Given each row contains two numbers that sum to a Fibonacci number in the third
+         And each row contains two numbers that sum to a Fibonacci number in the third
              | 0 | 1 | 1 |
              | 1 | 1 | 2 |
              | 1 | 2 | 3 |
              | 2 | 3 | 5 |
              | 3 | 5 | 8 |
-
-   Scenario: tables in nested stepdefs should not conflict
-       Given nested tables should match the right tables
-
-
-   Scenario: Vertical data table with no header (with table interpolation)
-       Given four in decimal is "4"
+         And four in decimal is "4"
          And five in decimal is "5"
          And six in decimal is "6"
          And four in binary is "100"
          And five in binary is "101"
          And six in binary is "110"
-       Given each column contains a number in decimal and binary form
+         And each column contains a number in decimal and binary form
              | ${four in decimal} | ${five in decimal} | ${six in decimal} |
              | ${four in binary}  | ${five in binary}  | ${six in binary}  |
+        When tables are nested in stepdefs
+        Then everything should be "ok"
+

--- a/features/sample/tables/NumberTables.meta
+++ b/features/sample/tables/NumberTables.meta
@@ -18,6 +18,7 @@
 
    @StepDef
    @DataTable(horizontal="decimal,binary")
+   @Context
    Scenario: single row without header contains a number in decimal and binary form
        Given name[1] should be "decimal"
          And name[2] should be "binary"
@@ -27,6 +28,7 @@
 
    @StepDef
    @DataTable(header="top")
+   @Context
    Scenario: single row with header contains a number in decimal and binary form
        Given name[1] should be "decimal"
          And name[2] should be "binary"
@@ -36,6 +38,7 @@
 
    @StepDef
    @DataTable(vertical="decimal,binary")
+   @Context
    Scenario: single column without header contains a number in decimal and binary form
        Given name[1] should be "decimal"
          And name[2] should be "binary"
@@ -45,6 +48,7 @@
 
    @StepDef
    @DataTable(header="left")
+   @Context
    Scenario: single column with header contains a number in decimal and binary form
        Given name[1] should be "decimal"
          And name[2] should be "binary"
@@ -54,6 +58,7 @@
 
   @StepDef
   @DataTable(horizontal="decimal,binary")
+  @Context
   Scenario: each row contains a number in decimal and binary form
       Given name[1] should be "decimal"
         And name[2] should be "binary"
@@ -67,6 +72,7 @@
 
   @StepDef
   @DataTable(vertical="decimal,binary")
+  @Context
   Scenario: each column contains a number in decimal and binary form
       Given name[1] should be "decimal"
         And name[2] should be "binary"
@@ -88,6 +94,7 @@
 
   @StepDef
   @DataTable(header="top")
+  @Context
   Scenario: each row contains a number and its square and cube
       Given name[1] should be "number"
         And name[2] should be "square"
@@ -106,6 +113,7 @@
 
   @StepDef
   @DataTable(header="left")
+  @Context
   Scenario: each column contains a number and its square and cube
       Given name[1] should be "number"
         And name[2] should be "square"
@@ -133,6 +141,7 @@
 
   @StepDef
   @DataTable(type="matrix")
+  @Context
   Scenario: the top and left numbers yield the product in the matrix
       Given vertex.name should be "x"
         And top.name[1] should be "1"
@@ -167,6 +176,7 @@
 
   @StepDef
   @DataTable(horizontal="a,b,c")
+  @Context
   Scenario: each row contains two numbers that sum to a Fibonacci number in the third
       Given a + b = c for each data record
        Then name[1] should be "a"
@@ -186,7 +196,8 @@
        Then the sum should be "${data[c]}"
 
   @StepDef
-  Scenario: nested tables should match the right tables
+  @Action
+  Scenario: tables are nested in stepdefs
       Given each row contains a number in decimal and binary form
              | 1 | 1  |
              | 2 | 10 |
@@ -195,6 +206,7 @@
 
   @StepDef
   Scenario: the nested table should match against its table
-       Given each column contains a number in decimal and binary form
+      Given each column contains a number in decimal and binary form
              | 4   | 5    | 6   |
              | 100 | 101  | 110 |
+       Then everything is "ok"

--- a/features/sample/templates/MatchJsonTemplates.feature
+++ b/features/sample/templates/MatchJsonTemplates.feature
@@ -19,6 +19,8 @@
 
  Background: Init
        Given my pet status is "available"
+        When I capture my pet status
+        Then my pet status should be "available"
 
 
  Scenario: Match static single line JSON template
@@ -26,12 +28,13 @@
            """
            {"id":42,"category":{"name":"pet"},"name":"tiger","status":"available"}
            """
-      Then my value should match template "{"id":42,"category":{"name":"pet"},"name":"tiger","status":"available"}"
-       And my value should match template
+      When I capture my value as contents
+      Then contents should match template "{"id":42,"category":{"name":"pet"},"name":"tiger","status":"available"}"
+       And contents should match template
            """
            {"id":42,"category":{"name":"pet"},"name":"tiger","status":"available"}
            """
-       And my value should match template file "features/sample/templates/json/StaticSingleLineTemplate.json"
+       And contents should match template file "features/sample/templates/json/StaticSingleLineTemplate.json"
 
 
  Scenario: Match static multi line JSON template
@@ -46,8 +49,9 @@
              "status": "available"
            }
            """
-      Then my value should not match template "{"id":42,"category":{"name":"pet"},"name":"tiger","status":"available"}"
-       And my value should match template
+      When I capture my value as contents
+      Then contents should not match template "{"id":42,"category":{"name":"pet"},"name":"tiger","status":"available"}"
+       And contents should match template
            """
            {
              "id": 42,
@@ -58,7 +62,7 @@
              "status": "available"
            }
            """
-       And my value should match template file "features/sample/templates/json/StaticMultiLineTemplate.json"
+       And contents should match template file "features/sample/templates/json/StaticMultiLineTemplate.json"
 
 
  Scenario: Match dynamic single line JSON template (1 ignore, 1 extract, 1 inject)
@@ -66,7 +70,8 @@
            """
            {"id":42,"category":{"name":"pet"},"name":"tiger","status":"available"}
            """
-      Then my value should match template "{"id":!{},"category":{"name":"pet"},"name":"@{pet name}","status":"${my pet status}"}"
+      When I capture my value as contents
+      Then contents should match template "{"id":!{},"category":{"name":"pet"},"name":"@{pet name}","status":"${my pet status}"}"
        And category name should be absent
        And pet id should be absent
        And pet name should be "tiger"
@@ -84,7 +89,10 @@
              "status": "available"
            }
            """
-      Then my value should match template
+       And the pet name is defined in my value by json path "$.name"
+       And the pet status is defined in my value by json path "$.status"
+      When I capture my value as contents
+      Then contents should match template
            """
            {
              "id": @{pet id},
@@ -97,9 +105,7 @@
            """
        And pet id should be "42"
        And category name should be "pet"
-       And the pet name is defined in my value by json path "$.name"
        And the pet name should be "tiger"
-       And the pet status is defined in my value by json path "$.status"
        And the pet status should be "available"
 
 
@@ -108,7 +114,8 @@
            """
            {"id":42,"category":{"name":"pet"},"name":"tiger","status":"available"}
            """
-      Then my value should match template file "features/sample/templates/json/DynamicSingleLineTemplate.json"
+      When I capture my value as contents
+      Then contents should match template file "features/sample/templates/json/DynamicSingleLineTemplate.json"
        And category name 1 should be absent
        And pet id 1 should be absent
        And pet name 1 should be "tiger"
@@ -125,10 +132,11 @@
              "status": "available"
            }
            """
-      Then my value should match template file "features/sample/templates/json/DynamicMultiLineTemplate.json"
+       And the pet name is defined in my value by json path "$.name"
+       And the pet status is defined in my value by json path "$.status"
+      When I capture my value as contents
+      Then contents should match template file "features/sample/templates/json/DynamicMultiLineTemplate.json"
        And pet id 2 should be "42"
        And category name 2 should be "pet"
-       And the pet name is defined in my value by json path "$.name"
        And the pet name should be "tiger"
-       And the pet status is defined in my value by json path "$.status"
        And the pet status should be "available"

--- a/features/sample/templates/MatchXmlTemplates.feature
+++ b/features/sample/templates/MatchXmlTemplates.feature
@@ -19,13 +19,15 @@
 
  Background: Init
        Given my pet status is "available"
-
+        When I capture my pet status
+        Then my pet status should be "available"
 
  Scenario: Match static single line XML template
      Given my value is
            """
            <result><id>42</id><category><name>pet</name></category><name>tiger</name><status>available</status></result>
            """
+      When I capture my value
       Then my value should match template "<result><id>42</id><category><name>pet</name></category><name>tiger</name><status>available</status></result>"
        And my value should match template
            """
@@ -46,6 +48,7 @@
                <status>available</status>
            </result>
            """
+      When I capture my value
       Then my value should not match template "<result><id>42</id><category><name>pet</name></category><name>tiger</name><status>available</status></result>"
        And my value should match template
            """
@@ -66,6 +69,7 @@
            """
            <result><id>42</id><category><name>pet</name></category><name>tiger</name><status>available</status></result>
            """
+      When I capture my value
       Then my value should match template "<result><id>!{}</id><category><name>pet</name></category><name>@{pet name}</name><status>${my pet status}</status></result>"
        And category name should be absent
        And pet id should be absent
@@ -84,6 +88,9 @@
                <status>available</status>
            </result>
            """
+       And the pet name is defined by the text in my value by xpath "result/name"
+       And the pet status is defined by the text in my value by xpath "result/status"
+      When I capture my value
       Then my value should match template
            """
            <result>
@@ -97,9 +104,7 @@
            """
        And pet id should be "42"
        And category name should be "pet"
-       And the pet name is defined by the text in my value by xpath "result/name"
        And the pet name should be "tiger"
-       And the pet status is defined by the text in my value by xpath "result/status"
        And the pet status should be "available"
 
 
@@ -108,6 +113,7 @@
            """
            <result><id>42</id><category><name>pet</name></category><name>tiger</name><status>available</status></result>
            """
+      When I capture my value
       Then my value should match template file "features/sample/templates/xml/DynamicSingleLineTemplate.xml"
        And category name 1 should be absent
        And pet id 1 should be absent
@@ -125,10 +131,11 @@
                <status>available</status>
            </result>
            """
+       And the pet name is defined by the text in my value by xpath "result/name"
+       And the pet status is defined by the text in my value by xpath "result/status"
+      When I capture my value
       Then my value should match template file "features/sample/templates/xml/DynamicMultiLineTemplate.xml"
        And pet id 2 should be "42"
        And category name 2 should be "pet"
-       And the pet name is defined by the text in my value by xpath "result/name"
        And the pet name should be "tiger"
-       And the pet status is defined by the text in my value by xpath "result/status"
        And the pet status should be "available"

--- a/features/sample/xml/xml.feature
+++ b/features/sample/xml/xml.feature
@@ -18,6 +18,9 @@
 
 Scenario: Pass XML to StepDef
     Given content is "<?xml version="1.0" encoding="UTF-8"?><Test>test</Test>"
-      And I process unquoted XML ${content}
+     When I process unquoted XML ${content}
       And I process quoted XML "${content}"
       And I process XML in content
+     Then xml1 should not be ""
+      And xml2 should not be ""
+      And xml3 should not be ""

--- a/src/main/scala/gwen/GwenSettings.scala
+++ b/src/main/scala/gwen/GwenSettings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 Branko Juric, Brady Wood
+ * Copyright 2014-2020 Branko Juric, Brady Wood
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package gwen
 
 import gwen.dsl.AssertionMode
 import gwen.dsl.FeatureMode
+import gwen.dsl.BehaviorRules
 import gwen.dsl.StateLevel
 
 /**
@@ -131,5 +132,16 @@ object GwenSettings {
     */
   def `gwen.associative.meta`: Boolean = 
     `gwen.auto.discover.meta` && Settings.getOpt("gwen.associative.meta").getOrElse("false").toBoolean
+
+  /**
+    * Provides access to the `gwen.behavior.rules` property setting used to determine whether strict, 
+    * or lenient rules around Given-When-Then usage should be enforced in features (default value is 
+    * `lenient`). When strict, scenarios and backgrounds must contain Given-When-Then ordered steps 
+    * and Given steps set context, When steps must perform actions, and Then or But steps must perform 
+    * assertions. When `leneient` no behavioral rules are enforced. Not that `gwen.behaviour.rules` is 
+    * an alias for this setting.
+    */
+    def `gwen.behavior.rules`: BehaviorRules.Value = 
+      Settings.getOpt("gwen.behavior.rules").orElse(Settings.getOpt("gwen.behaviour.rules")).map(_.toLowerCase).map(BehaviorRules.withName).getOrElse(BehaviorRules.lenient)
 
 }

--- a/src/main/scala/gwen/Predefs.scala
+++ b/src/main/scala/gwen/Predefs.scala
@@ -143,7 +143,7 @@ object Predefs extends LazyLogging {
     def isFeatureFile(file: File): Boolean = hasFileExtension("feature", file)
     def isMetaFile(file: File): Boolean = hasFileExtension("meta", file)
     def isCsvFile(file: File): Boolean = hasFileExtension("csv", file)
-    def hasFileExtension(extension: String, file: File): Boolean = file.isFile && file.getName.endsWith(s".$extension")
+    def hasFileExtension(extension: String, file: File): Boolean = !file.isDirectory && file.getName.endsWith(s".$extension")
     def recursiveScan(dir: File, extension: String): List[File] = {
       val files = dir.listFiles
       val metas = files.filter(file => hasFileExtension(extension, file)).toList

--- a/src/main/scala/gwen/Settings.scala
+++ b/src/main/scala/gwen/Settings.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 Branko Juric, Brady Wood
+ * Copyright 2015-2020 Branko Juric, Brady Wood
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,8 @@ import scala.collection.mutable
   * @author Branko Juric
   */
 object Settings {
+
+  object Lock
 
   val userProperties: Option[File] = FileIO.getUserFile("gwen.properties")
   val workingProperties: Option[File] = FileIO.getFileOpt("gwen.properties")
@@ -232,6 +234,9 @@ object Settings {
     */
   private[gwen] def add(name: String, value: String, overrideIfExists: Boolean): Unit = {
     if (overrideIfExists || !contains(name)) {
+      if (overrideIfExists && localSettings.get.containsKey(name)) {
+        localSettings.get.setProperty(name, value)
+      }
       set(name, value)
     }
   }
@@ -261,6 +266,12 @@ object Settings {
     */
   def clearLocal(): Unit = {
     localSettings.get.clear()
+  }
+
+  def exclusively[T](body: => T):T = {
+    Settings.Lock.synchronized {
+      body
+    }
   }
   
 }

--- a/src/main/scala/gwen/dsl/Keywords.scala
+++ b/src/main/scala/gwen/dsl/Keywords.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Branko Juric, Brady Wood
+ * Copyright 2017-2020 Branko Juric, Brady Wood
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package gwen.dsl
 
+import gwen.GwenSettings
 import scala.language.postfixOps
 
 object FeatureKeyword extends Enumeration {
@@ -37,8 +38,22 @@ object FeatureSymbol extends Enumeration {
 
 }
 
-object StepKeyword extends Enumeration {
+object BehaviorType extends Enumeration {
+  
+  type BehaviorType = Value
+  val Context, Action, Assertion = Value
 
+  def of(keyword: StepKeyword.Value): BehaviorType.Value = keyword match {
+    case StepKeyword.Given => BehaviorType.Context
+    case StepKeyword.When => BehaviorType.Action
+    case StepKeyword.Then | StepKeyword.But => BehaviorType.Assertion
+  }
+
+}
+
+object StepKeyword extends Enumeration {
+  
+  type StepKeyword = Value
   val Given, When, Then, And, But = Value
 
   /** List of all keyword names. */
@@ -53,15 +68,29 @@ object ReservedKeyword {
 object AssertionMode extends Enumeration {
   type AssertionMode = Value
   val hard, soft, sustained = Value
+  def isHard = GwenSettings.`gwen.assertion.mode` == hard
+  def isSoft = GwenSettings.`gwen.assertion.mode` == soft
+  def isSustained = GwenSettings.`gwen.assertion.mode` == sustained
 }
 
 object StateLevel extends Enumeration {
   type StateLevel = Value
   val scenario, feature = Value
+  def isScenario = GwenSettings.`gwen.state.level` == scenario
+  def isFeature = GwenSettings.`gwen.state.level` == feature
 }
 
 object FeatureMode extends Enumeration {
-  type Feature = Value
+  type FeatureMode = Value
   val declarative, imperative = Value
+  def isDeclarative = GwenSettings.`gwen.feature.mode` == declarative
+  def isImperative = GwenSettings.`gwen.feature.mode` == imperative
+}
+
+object BehaviorRules extends Enumeration {
+  type BehaviorRules = Value
+  val strict, lenient = Value
+  def isStrict = GwenSettings.`gwen.behavior.rules` == strict
+  def isLenient = GwenSettings.`gwen.behavior.rules` == lenient
 }
 

--- a/src/main/scala/gwen/dsl/SpecType.scala
+++ b/src/main/scala/gwen/dsl/SpecType.scala
@@ -27,5 +27,8 @@ object SpecType extends Enumeration {
 
   val feature, meta = Value
 
+  def isFeature(specType: SpecType.Value):Boolean = specType == feature
+  def isMeta(specType: SpecType.Value):Boolean = specType == meta
+
 }
 

--- a/src/main/scala/gwen/eval/EnvState.scala
+++ b/src/main/scala/gwen/eval/EnvState.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Branko Juric, Brady Wood
+ * Copyright 2014-2020 Branko Juric, Brady Wood
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,8 @@ import gwen.Predefs.Kestrel
 import java.io.File
 import gwen.dsl.Scenario
 import gwen.dsl.Step
+import gwen.dsl.StepKeyword
+import gwen.dsl.BehaviorType
 
 class EnvState(val scopes: ScopedDataStack) {
 
@@ -30,7 +32,10 @@ class EnvState(val scopes: ScopedDataStack) {
   private var attachmentPrefix = padWithZeroes(1)
 
   /** Map of for-each StepDefs. */
-  private var foreachStepDefs: Map[String, Scenario] = Map[String, Scenario]()
+  private var foreachStepDefs = Map[String, Scenario]()
+
+  /** Stack of behaviors. */
+  private var behaviors = List[BehaviorType.Value]()
 
   /** Checks if attachments exist. */
   def hasAttachments: Boolean = attachments.nonEmpty
@@ -86,6 +91,23 @@ class EnvState(val scopes: ScopedDataStack) {
           foreachStepDefs -= step.uniqueId 
         }
       }
+
+    /** Adds the given behavior to the top of the stack. */
+    def addBehavior(behavior: BehaviorType.Value): Unit = {
+      behaviors = behavior :: behaviors
+    }
+
+    /** Removes the behavior at the top of the stack. */
+    def popBehavior(): Option[BehaviorType.Value] = behaviors match {
+      case head::tail => 
+        behaviors = tail
+        Some(head)
+      case _ =>
+        None
+    }
+
+    /** Gets the behavior at the top of the stack. */
+    def currentBehavior: Option[BehaviorType.Value] = behaviors.headOption
 }
 
 object EnvState {

--- a/src/main/scala/gwen/eval/EvalRules.scala
+++ b/src/main/scala/gwen/eval/EvalRules.scala
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2020 Branko Juric, Brady Wood
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gwen.eval
+
+import gwen.dsl._
+import gwen.errors._
+import gwen.GwenSettings
+import gwen.Predefs.FileIO
+import java.io.File
+
+ /**
+  * Enfores certain rules depending on `gwen.feature.mode` and `gwen.behavior.rules` settings.
+  */
+trait EvalRules {
+
+  /**
+    * Checks that a background satisfies behavior rules before evaluation.
+    *
+    * @param background the background  to check
+    * @param specFile the file the background was loaded from
+    */
+  def checkBackgroundRules(background: Background, specFile: Option[File]): Unit = {
+    if (BehaviorRules.isStrict && isFeatureFile(specFile)) {
+      if (!isProperBehavior(background.steps)) {
+        improperBehaviorError(background, "Background", specFile)
+      }
+    }
+  }
+
+  /**
+    * Checks that a scenario or stepdef satisfies behavior rules before evaluation.
+    *
+    * @param scenario the scenario to check
+    * @param specFile the file the scenario was loaded from
+    */
+  def checkScenarioRules(scenario: Scenario, specFile: Option[File]): Unit = {
+    if (isFeatureFile(specFile)) {
+      if (FeatureMode.isDeclarative && scenario.isStepDef) {
+        imperativeStepDefError(scenario, specFile)
+      }
+      if (BehaviorRules.isStrict && !(FeatureMode.isImperative && scenario.isStepDef)) {
+        if (!isProperBehavior(scenario.steps)) {
+          improperBehaviorError(scenario, scenario.keyword, specFile)
+        }
+      }
+    }
+  }
+
+  /**
+    * Checks that a step def called in a feature satisfies behavoiur rules at evaluation.
+    *
+    * @param step the step to check
+    * @param env the environment context
+    */
+  def checkStepDefRules[T <: EnvContext](step: Step, env: T): Unit = {
+    if (env.isEvaluatingTopLevelStep && env.isEvaluatingFeatureFile) {
+      if (BehaviorRules.isStrict) {
+        step.stepDef foreach { stepDef =>
+          stepDef.behaviorTag match {
+            case Some(behaviorTag) =>
+              checkStepRules(step, BehaviorType.withName(behaviorTag.name), env)
+            case _ =>
+              undefinedStepDefBehaviorError(stepDef, stepDef.metaFile)
+          }
+        }
+      }
+    }
+  }
+
+  /**
+    * Checks that a step called in a feature satisfies behavoiur rules at evaluation.
+    *
+    * @param step the step to check
+    * @param actualBehavior the actual behavior type of the step
+    * @param env the environment context
+    */
+  def checkStepRules[T <: EnvContext](step: Step, actualBehavior: BehaviorType.Value, env: T): Unit = {
+    if (env.isEvaluatingTopLevelStep && env.isEvaluatingFeatureFile) {
+      if (FeatureMode.isDeclarative && step.stepDef.isEmpty) {
+        imperativeStepError(step)
+      }
+      if (BehaviorRules.isStrict) {
+        env.currentBehavior foreach { expectedBehavior =>
+          if (actualBehavior != expectedBehavior) {
+            unexpectedBehaviorError(step, expectedBehavior, actualBehavior, env.specFile)
+          } else if (step.keyword != StepKeyword.And) {
+            val stepBehavior = BehaviorType.of(step.keyword) 
+            if (stepBehavior != expectedBehavior) {
+              unexpectedBehaviorError(step, expectedBehavior, stepBehavior, env.specFile)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private def isProperBehavior(steps: List[Step]): Boolean =
+    steps.map(_.keyword).filter(_ != StepKeyword.And).mkString("-").matches("Given-When-Then(-But)?")
+
+  private def isFeatureFile(specFile: Option[File]):Boolean = 
+    specFile.map(FileIO.isFeatureFile).getOrElse(false)
+
+}

--- a/src/main/scala/gwen/eval/GwenLauncher.scala
+++ b/src/main/scala/gwen/eval/GwenLauncher.scala
@@ -106,7 +106,7 @@ class GwenLauncher[T <: EnvContext](interpreter: GwenInterpreter[T]) extends Laz
     val counter = new AtomicInteger(0)
     val started = new ThreadLocal[Boolean]()
     started.set(false)
-    implicit val ec = if (options.parallelFeatures || GwenSettings.`gwen.state.level` == StateLevel.feature) {
+    implicit val ec = if (options.parallelFeatures || StateLevel.isFeature) {
       ExecutionContext.Implicits.global
     } else {
       val noOfProcessors = Runtime.getRuntime().availableProcessors()

--- a/src/main/scala/gwen/eval/support/DefaultEngineSupport.scala
+++ b/src/main/scala/gwen/eval/support/DefaultEngineSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Branko Juric, Brady Wood
+ * Copyright 2015-2020 Branko Juric, Brady Wood
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ package gwen.eval.support
 import scala.sys.process.stringSeqToProcess
 import scala.sys.process.stringToProcess
 import gwen.Predefs.RegexContext
-import gwen.dsl.{FlatTable, Passed, Step}
+import gwen.dsl.{BehaviorType, FlatTable, Passed, Step}
 import gwen.eval.{EnvContext, EvalEngine}
 import gwen.errors._
 import gwen.Settings
@@ -92,21 +92,26 @@ trait DefaultEngineSupport[T <: EnvContext] extends EvalEngine[T] {
     step.expression match {
 
       case r"""my (.+?)$name (?:property|setting) (?:is|will be) "(.*?)"$$$value""" =>
+        checkStepRules(step, BehaviorType.Context, env)
         Settings.setLocal(name, value)
 
       case r"""I reset my (.+?)$name (?:property|setting)""" =>
+        checkStepRules(step, BehaviorType.Context, env)
         Settings.clearLocal(name)
 
       case r"""(.+?)$attribute (?:is|will be) "(.*?)"$$$value""" => step.orDocString(value) tap { value =>
+        checkStepRules(step, BehaviorType.Context, env)
         env.topScope.set(attribute, value)
       }
 
       case r"""I wait ([0-9]+?)$duration second(?:s?)""" =>
+        checkStepRules(step, BehaviorType.Action, env)
         env.perform {
           Thread.sleep(duration.toLong * 1000)
         }
       
       case r"""I execute system process "(.+?)"$$$systemproc""" => step.orDocString(systemproc) tap { systemproc =>
+        checkStepRules(step, BehaviorType.Action, env)
         env.perform {
           systemproc.! match {
             case 0 =>
@@ -116,6 +121,7 @@ trait DefaultEngineSupport[T <: EnvContext] extends EvalEngine[T] {
       }
 
       case r"""I execute a unix system process "(.+?)"$$$systemproc""" => step.orDocString(systemproc) tap { systemproc =>
+        checkStepRules(step, BehaviorType.Action, env)
         env.perform {
           Seq("/bin/sh", "-c", systemproc).! match {
             case 0 =>
@@ -125,11 +131,13 @@ trait DefaultEngineSupport[T <: EnvContext] extends EvalEngine[T] {
       }
 
       case r"""I execute javascript "(.+?)$javascript"""" => step.orDocString(javascript) tap { javascript =>
+        checkStepRules(step, BehaviorType.Action, env)
         env.evaluateJS(javascript)
       }
 
 
       case r"""I capture (.+?)$attribute by javascript "(.+?)"$$$expression""" => step.orDocString(expression) tap { expression =>
+        checkStepRules(step, BehaviorType.Action, env)
         val value = Option(env.evaluateJS(env.formatJSReturn(env.interpolate(expression)(env.getBoundReferenceValue)))).map(_.toString).orNull
         env.topScope.set(attribute, value tap { content =>
           env.addAttachment(attribute, "txt", content)
@@ -137,6 +145,7 @@ trait DefaultEngineSupport[T <: EnvContext] extends EvalEngine[T] {
       }
 
       case r"""I capture the (text|node|nodeset)$targetType in (.+?)$source by xpath "(.+?)"$expression as (.+?)$$$name""" =>
+        checkStepRules(step, BehaviorType.Action, env)
         val src = env.getBoundReferenceValue(source)
         val result = env.evaluateXPath(expression, src, env.XMLNodeType.withName(targetType)) tap { content =>
           env.addAttachment(name, "txt", content)
@@ -144,6 +153,7 @@ trait DefaultEngineSupport[T <: EnvContext] extends EvalEngine[T] {
         env.topScope.set(name, result)
 
       case r"""I capture the text in (.+?)$source by regex "(.+?)"$expression as (.+?)$$$name""" =>
+        checkStepRules(step, BehaviorType.Action, env)
         val src = env.getBoundReferenceValue(source)
         val result = env.extractByRegex(expression, src) tap { content =>
           env.addAttachment(name, "txt", content)
@@ -151,6 +161,7 @@ trait DefaultEngineSupport[T <: EnvContext] extends EvalEngine[T] {
         env.topScope.set(name, result)
 
       case r"""I capture the content in (.+?)$source by json path "(.+?)"$expression as (.+?)$$$name""" =>
+        checkStepRules(step, BehaviorType.Action, env)
         val src = env.getBoundReferenceValue(source)
         val result = env.evaluateJsonPath(expression, src) tap { content =>
           env.addAttachment(name, "txt", content)
@@ -158,18 +169,21 @@ trait DefaultEngineSupport[T <: EnvContext] extends EvalEngine[T] {
         env.topScope.set(name, result)
 
       case r"""I capture (.+?)$source as (.+?)$$$attribute""" =>
+        checkStepRules(step, BehaviorType.Action, env)
         val value = env.getBoundReferenceValue(source)
         env.topScope.set(attribute, value tap { content =>
           env.addAttachment(attribute, "txt", content)
         })
 
       case r"""I capture (.+?)$$$attribute""" =>
+        checkStepRules(step, BehaviorType.Action, env)
         val value = env.getBoundReferenceValue(attribute)
         env.topScope.set(attribute, value tap { content =>
           env.addAttachment(attribute, "txt", content)
         })
 
       case r"""I base64 decode (.+?)$attribute as (.+?)$$$name""" =>
+        checkStepRules(step, BehaviorType.Action, env)
         val source = env.getBoundReferenceValue(attribute)
         val result = env.decodeBase64(source) tap { content =>
           env.addAttachment(name, "txt", content)
@@ -177,6 +191,7 @@ trait DefaultEngineSupport[T <: EnvContext] extends EvalEngine[T] {
         env.topScope.set(name, result)
 
       case r"""I base64 decode (.+?)$attribute""" =>
+        checkStepRules(step, BehaviorType.Action, env)
         val source = env.getBoundReferenceValue(attribute)
         val result = env.decodeBase64(source) tap { content =>
           env.addAttachment(attribute, "txt", content)
@@ -184,6 +199,7 @@ trait DefaultEngineSupport[T <: EnvContext] extends EvalEngine[T] {
         env.topScope.set(attribute, result)
 
       case r"""(.+?)$attribute (?:is|will be) defined by (javascript|system process|property|setting|file)$attrType "(.+?)"$$$expression""" => step.orDocString(expression) tap { expression =>
+        checkStepRules(step, BehaviorType.Context, env)
         attrType match {
           case "javascript" => env.scopes.set(s"$attribute/javascript", expression)
           case "system process" => env.scopes.set(s"$attribute/sysproc", expression)
@@ -193,28 +209,33 @@ trait DefaultEngineSupport[T <: EnvContext] extends EvalEngine[T] {
       }
 
       case r"""(.+?)$attribute (?:is|will be) defined by the (text|node|nodeset)$targetType in (.+?)$source by xpath "(.+?)"$$$expression""" => step.orDocString(expression) tap { expression =>
+        checkStepRules(step, BehaviorType.Context, env)
         env.scopes.set(s"$attribute/xpath/source", source)
         env.scopes.set(s"$attribute/xpath/targetType", targetType)
         env.scopes.set(s"$attribute/xpath/expression", expression)
       }
 
       case r"""(.+?)$attribute (?:is|will be) defined in (.+?)$source by regex "(.+?)"$$$expression""" => step.orDocString(expression) tap { expression =>
+        checkStepRules(step, BehaviorType.Context, env)
         env.scopes.set(s"$attribute/regex/source", source)
         env.scopes.set(s"$attribute/regex/expression", expression)
       }
 
       case r"""(.+?)$attribute (?:is|will be) defined in (.+?)$source by json path "(.+?)"$$$expression""" => step.orDocString(expression) tap { expression =>
+        checkStepRules(step, BehaviorType.Context, env)
         env.scopes.set(s"$attribute/json path/source", source)
         env.scopes.set(s"$attribute/json path/expression", expression)
       }
 
       case r"""(.+?)$attribute (?:is|will be) defined by sql "(.+?)"$selectStmt in the (.+?)$dbName database""" =>
+        checkStepRules(step, BehaviorType.Context, env)
         Settings.get(s"gwen.db.${dbName}.driver")
         Settings.get(s"gwen.db.${dbName}.url")
         env.scopes.set(s"$attribute/sql/selectStmt", selectStmt)
         env.scopes.set(s"$attribute/sql/dbName", dbName)
 
       case r"""(.+?)$attribute (?:is|will be) defined in the (.+?)$dbName database by sql "(.+?)"$$$selectStmt""" => step.orDocString(selectStmt) tap { selectStmt =>
+        checkStepRules(step, BehaviorType.Context, env)
         Settings.get(s"gwen.db.${dbName}.driver")
         Settings.get(s"gwen.db.${dbName}.url")
         env.scopes.set(s"$attribute/sql/selectStmt", selectStmt)
@@ -222,6 +243,7 @@ trait DefaultEngineSupport[T <: EnvContext] extends EvalEngine[T] {
       }
 
       case r"""I update the (.+?)$dbName database by sql "(.+?)"$$$updateStmt""" => step.orDocString(updateStmt) tap { updateStmt =>
+        checkStepRules(step, BehaviorType.Action, env)
         Settings.get(s"gwen.db.${dbName}.driver")
         Settings.get(s"gwen.db.${dbName}.url")
         val rowsAffected = env.executeSQLUpdate(updateStmt, dbName)
@@ -229,6 +251,7 @@ trait DefaultEngineSupport[T <: EnvContext] extends EvalEngine[T] {
       }
 
       case r"""(.+?)$source at (json path|xpath)$matcher "(.+?)"$path should( not)?$negation (be|contain|start with|end with|match regex|match template|match template file)$operator "(.*?)"$$$expression""" => step.orDocString(expression) tap { expression =>
+        checkStepRules(step, BehaviorType.Assertion, env)
         val expected = env.parseExpression(operator, expression)
         env.perform {
           val src = env.scopes.get(source)
@@ -249,6 +272,7 @@ trait DefaultEngineSupport[T <: EnvContext] extends EvalEngine[T] {
       }
 
       case r"""(.+?)$attribute should( not)?$negation (be|contain|start with|end with|match regex|match xpath|match json path|match template|match template file)$operator "(.*?)"$$$expression""" => step.orDocString(expression) tap { expression =>
+        checkStepRules(step, BehaviorType.Assertion, env)
         val actualValue = env.getBoundReferenceValue(attribute)
         val expected = env.parseExpression(operator, expression)
         env.perform {
@@ -265,6 +289,7 @@ trait DefaultEngineSupport[T <: EnvContext] extends EvalEngine[T] {
       }
 
       case r"""(.+?)$attribute should be absent""" =>
+        checkStepRules(step, BehaviorType.Assertion, env)
         env.perform {
           assert(Try(env.getBoundReferenceValue(attribute)).isFailure, s"Expected $attribute to be absent")
         }

--- a/src/main/scala/gwen/report/JUnitReportFormatter.scala
+++ b/src/main/scala/gwen/report/JUnitReportFormatter.scala
@@ -27,6 +27,7 @@ import gwen.eval.FeatureResult
 import gwen.eval.FeatureSummary
 import gwen.eval.GwenOptions
 import gwen.eval.FeatureUnit
+import gwen.eval.SpecNormaliser
 import gwen.Predefs.Formatting._
 import scala.sys.process._
 

--- a/src/test/resources/gwen/evalrules/InlinedStepDef.feature
+++ b/src/test/resources/gwen/evalrules/InlinedStepDef.feature
@@ -1,12 +1,12 @@
 #
-# Copyright 2018 Branko Juric, Brady Wood
-#
+# Copyright 2020 Branko Juric, Brady Wood
+# 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#
+# 
 #     http://www.apache.org/licenses/LICENSE-2.0
-#
+# 
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,22 +14,15 @@
 # limitations under the License.
 #
 
- Feature: XML meta
+ Feature: Calculator
+
+Scenario: Sum two values
+  Given a is "1"
+    And b is "2"
+   When I add a to b to get c
+   Then "c" should be "3"
 
 @StepDef
-@Action
-Scenario: I process unquoted XML <xml>
-    Given xml1 is "$<xml>"
-      And xml1 should match xpath "/Test"
-
-@StepDef
-@Action
-Scenario: I process quoted XML "<xml>"
-    Given xml2 is "$<xml>"
-      And xml2 should match xpath "/Test"
-
-@StepDef
-@Action
-Scenario: I process XML in <xml>
-    Given xml3 is "${$<xml>}"
-     And $<xml> should match xpath "/Test"
+@When
+Scenario: I add a to b to get c
+    Given c is defined by javascript "${a} + ${b}"

--- a/src/test/scala/gwen/BaseTest.scala
+++ b/src/test/scala/gwen/BaseTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Brady Wood, Branko Juric
+ * Copyright 2019-2020 Brady Wood, Branko Juric
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,15 +23,24 @@ abstract class BaseTest extends FlatSpec {
 
   val levels = Table ( ("level"), ("feature"), ("scenario") )
 
-  def withSetting[T](name: String, value: String)(f: => T):T = {
-    Settings.synchronized {
-      val original = Settings.getOpt(name)
+  def withSetting[T](name: String, value: String)(body: => T):T = {
+    if (name.startsWith("gwen.")) {
       try {
-        Settings.set(name, value)
-        f
+        Settings.setLocal(name, value)
+        body
       } finally {
-        original.fold(Settings.clear(name)) { v =>
-          Settings.set(name, v)
+        Settings.clearLocal()
+      }
+    } else {
+      Settings.exclusively {
+        val original = Settings.getOpt(name)
+        try {
+          Settings.set(name, value)
+          body
+        } finally {
+          original.fold(Settings.clear(name)) { v =>
+            Settings.set(name, v)
+          }
         }
       }
     }

--- a/src/test/scala/gwen/dsl/EvalStatusTest.scala
+++ b/src/test/scala/gwen/dsl/EvalStatusTest.scala
@@ -18,6 +18,7 @@ package gwen.dsl
 
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
+import gwen.eval.SpecNormaliser
 
 class EvalStatusTest extends FlatSpec with Matchers with SpecNormaliser with GherkinParser {
 

--- a/src/test/scala/gwen/dsl/PrettyPrintParserRules1Test.scala
+++ b/src/test/scala/gwen/dsl/PrettyPrintParserRules1Test.scala
@@ -19,6 +19,7 @@ package gwen.dsl
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 import scala.util.Success
+import gwen.eval.SpecNormaliser
 
 class PrettyPrintParserRules1Test extends FlatSpec with Matchers with SpecNormaliser with GherkinParser {
 

--- a/src/test/scala/gwen/dsl/PrettyPrintParserRules2Test.scala
+++ b/src/test/scala/gwen/dsl/PrettyPrintParserRules2Test.scala
@@ -19,6 +19,7 @@ package gwen.dsl
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 import scala.util.Success
+import gwen.eval.SpecNormaliser
 
 class PrettyPrintParserRules2Test extends FlatSpec with Matchers with SpecNormaliser with GherkinParser {
 

--- a/src/test/scala/gwen/dsl/PrettyPrintParserRules3Test.scala
+++ b/src/test/scala/gwen/dsl/PrettyPrintParserRules3Test.scala
@@ -19,6 +19,7 @@ package gwen.dsl
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 import scala.util.Success
+import gwen.eval.SpecNormaliser
 
 class PrettyPrintParserRules3Test extends FlatSpec with Matchers with SpecNormaliser with GherkinParser {
 

--- a/src/test/scala/gwen/dsl/PrettyPrintParserTest.scala
+++ b/src/test/scala/gwen/dsl/PrettyPrintParserTest.scala
@@ -19,6 +19,7 @@ package gwen.dsl
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
 import scala.util.Success
+import gwen.eval.SpecNormaliser
 
 class PrettyPrintParserTest extends FlatSpec with Matchers with SpecNormaliser with GherkinParser {
 

--- a/src/test/scala/gwen/dsl/ScenarioParserTest.scala
+++ b/src/test/scala/gwen/dsl/ScenarioParserTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 Branko Juric, Brady Wood
+ * Copyright 2014-2020 Branko Juric, Brady Wood
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/gwen/eval/EvalEngineTest.scala
+++ b/src/test/scala/gwen/eval/EvalEngineTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 Branko Juric, Brady Wood
+ * Copyright 2014-2020 Branko Juric, Brady Wood
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,18 +64,21 @@ class EvalEngineTest extends FlatSpec with Matchers {
   
   "Step that is a stepdef" should "should be evaluated" in {
     val env = engine.init(new GwenOptions())
-    val stepDef = Scenario(List[Tag]("@StepDef"), "I assign x, y, and z", Nil, None, List(
+    val stepDef = Scenario(List[Tag]("@StepDef", "@Action"), "I assign x, y, and z", Nil, None, List(
         Step(StepKeyword.Given, """x is "1""""),
-        Step(StepKeyword.When, """y is "2""""),
-        Step(StepKeyword.Then, """z is "3"""")))
+        Step(StepKeyword.And, """y is "2""""),
+        Step(StepKeyword.And, """z is "3""""),
+        Step(StepKeyword.When, """I capture x as a"""),
+        Step(StepKeyword.Then, """a should be "1"""")))
     env.addStepDef(stepDef)
     env.scopes.set("y", "1")
-    var step = Step(StepKeyword.Given, "I assign x, y, and z")
+    var step = Step(StepKeyword.When, "I assign x, y, and z")
     step = engine.evaluateStep(step, env)
     step.evalStatus.status should be (StatusKeyword.Passed)
     env.scopes.get("x") should be ("1")
     env.scopes.get("y") should be ("2")
     env.scopes.get("z") should be ("3")
+    env.scopes.get("a") should be ("1")
     step.stepDef should not be (None)
   }
   

--- a/src/test/scala/gwen/eval/EvalRulesTest.scala
+++ b/src/test/scala/gwen/eval/EvalRulesTest.scala
@@ -1,0 +1,705 @@
+/*
+ * Copyright 2020 Branko Juric, Brady Wood
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gwen.eval
+
+import org.scalatest.Matchers
+import gwen.BaseTest
+import gwen.eval.support.DefaultEngineSupport
+import gwen.dsl._
+import gwen.errors._
+import gwen.Predefs.Kestrel
+
+import scala.io.Source
+import java.io.File
+
+
+class EvalRulesTest extends BaseTest with Matchers with GherkinParser with EvalRules {
+
+    private def parseFeature(file: File): FeatureSpec = 
+        parseFeatureSpec(Source.fromFile(file).mkString).get
+
+    private def createScenario(steps: String): Scenario = {
+        val input = s"""
+        | Scenario: scenario
+        |     $steps
+        | """.stripMargin
+        parseFeatureSpec(s"Feature: feature\n$input").map(_.scenarios.head).get
+    }
+
+    private def createBackground(steps: String): Background = {
+        val input = s"""
+        | Background: background
+        |       $steps
+        | """.stripMargin
+        parseFeatureSpec(s"Feature: feature\n$input").map(_.background.head).get
+    }
+
+    private def createStep(step: String): Step = parseStep(step).get
+
+    val env = new EnvContext(GwenOptions()) {
+        topScope.pushObject("spec.file", featureFile)
+    }
+
+    val featureFile = new File(getClass.getResource("/gwen/evalrules/InlinedStepDef.feature").getFile)
+    val feature = parseFeature(featureFile)
+    val givenStep = createStep("Given I set the context")
+    val whenStep = createStep("When I peform an action")
+    val thenStep = createStep("Then this should happen")
+    val andStep = createStep("And this")
+    val butStep = createStep("But that")
+
+    "declartive feature with stepdef" should "fail declarative rules check" in {    
+        withSetting("gwen.feature.mode", "declarative") {
+            val stepDef = feature.scenarios(1)
+            withSpecFile(SpecType.feature) { specFile =>
+                intercept[ImperativeStepDefException] {
+                    checkScenarioRules(stepDef, Some(specFile))
+                }
+            }
+            withSpecFile(SpecType.meta) { specFile =>
+                checkScenarioRules(stepDef, Some(specFile))
+            }
+        }
+    }
+
+    "imperative feature with stepdef" should "pass imperative rules check" in {
+        withSetting("gwen.feature.mode", "imperative") {
+            SpecType.values.foreach { specType =>
+                withSpecFile(specType) { specFile =>
+                    val stepDef = feature.scenarios(1)
+                    checkScenarioRules(stepDef, Some(specFile))
+                }
+            }
+        }
+    }
+
+    "imperative feature with stepdef with behavior tag" should "pass strict behavior rules check" in {
+        withSetting("gwen.feature.mode", "imperative") {
+            withSetting("gwen.behavior.rules", "strict") {
+                SpecType.values.foreach { specType =>
+                    withSpecFile(specType) { specFile =>
+                        val stepDef = feature.scenarios(1)
+                        checkScenarioRules(stepDef, Some(specFile))
+                    }
+                }
+            }
+        }
+    }
+
+    "imperative feature with stepdef but no behavior tag" should "fail strict behavior rules check" in {
+        withSetting("gwen.feature.mode", "imperative") {
+            withSetting("gwen.behavior.rules", "strict") {
+                val stepDef = feature.scenarios(1)  
+                val stepDefNobehaviorTag = Scenario(
+                    List(Tag("StepDef")),
+                    stepDef.keyword,
+                    stepDef.name,
+                    stepDef.description,
+                    stepDef.background,
+                    stepDef.steps,
+                    stepDef.isOutline,
+                    stepDef.examples,
+                    stepDef.metaFile) tap { sd => sd.pos = stepDef.pos }
+                val step = Step(feature.scenarios(0).steps(2), stepDefNobehaviorTag)
+                withSpecFile(SpecType.feature) { _ =>
+                    intercept[UndefinedStepDefBehaviorException] {
+                        checkStepDefRules(step, env)
+                    }
+                }
+                withSpecFile(SpecType.meta) { _ =>
+                    checkStepDefRules(step, env)
+                }
+            }
+        }
+    }
+
+    "declartive feature with imperative step" should "fail declarative rules check" in {
+        withSetting("gwen.feature.mode", "declarative") {
+            val step = feature.scenarios(0).steps(1)
+            withSpecFile(SpecType.feature) { _ =>
+                intercept[ImperativeStepException] {
+                    checkStepRules(step, BehaviorType.Action, env)
+                }
+            }
+            withSpecFile(SpecType.meta) { _ =>
+                checkStepRules(step, BehaviorType.Action, env)
+            }
+        }
+    }
+
+    "imperative feature with imperative step" should "pass imperative rules check" in {
+        withSetting("gwen.feature.mode", "imperative") {
+            val step = feature.scenarios(0).steps(1)
+            SpecType.values foreach { specType =>
+                withSpecFile(specType) { _ =>
+                    checkStepRules(step, BehaviorType.Action, env)
+                }
+            }
+        }
+    }
+
+    "scenarios or backgrounds with G-W-T sequence" should "pass strict and lenient behavior rules checks" in {
+        
+        val steps = """
+        |     Given I set the context
+        |      When I perform an action
+        |      Then this should happen
+        | """.stripMargin
+        val scenario = createScenario(steps)
+        val background = createBackground(steps)
+
+        SpecType.values foreach { specType =>
+            withSpecFile(specType) { specFile =>
+                withSetting("gwen.behavior.rules", "strict") {
+                    checkScenarioRules(scenario, Some(specFile))
+                    checkBackgroundRules(background, Some(specFile))
+                }
+                withSetting("gwen.behavior.rules", "lenient") {
+                    checkScenarioRules(scenario, Some(specFile))
+                    checkBackgroundRules(background, Some(specFile))
+                }
+            }
+        }
+    }
+
+    "scenarios or backgrounds with G-W-T-B sequence" should "pass strict and lenient behavior rules checks" in {
+        
+        val steps = """
+        |     Given I set the context
+        |      When I perform an action
+        |      Then this should happen
+        |       But this should not happen
+        | """.stripMargin
+        val scenario = createScenario(steps)
+        val background = createBackground(steps)
+
+        SpecType.values foreach { specType =>
+            withSpecFile(specType) { specFile =>
+                withSetting("gwen.behavior.rules", "strict") {
+                    checkScenarioRules(scenario, Some(specFile))
+                    checkBackgroundRules(background, Some(specFile))
+                }
+                withSetting("gwen.behavior.rules", "lenient") {
+                    checkScenarioRules(scenario, Some(specFile))
+                    checkBackgroundRules(background, Some(specFile))
+                }
+            }
+        }
+    }
+
+    "scenarios or backgrounds with G-A-W-A-T-A-B sequence" should "pass strict and lenient behavior rules checks" in {
+        
+        val steps = """
+        |     Given I set some context
+        |       And I set more context
+        |      When I perform an action
+        |       And I perform another action
+        |      Then this should happen
+        |       And that should happen
+        |       But this should not happen
+        | """.stripMargin
+        val scenario = createScenario(steps)
+        val background = createBackground(steps)
+
+        SpecType.values foreach { specType =>
+            withSpecFile(specType) { specFile =>
+                withSetting("gwen.behavior.rules", "strict") {
+                    checkScenarioRules(scenario, Some(specFile))
+                    checkBackgroundRules(background, Some(specFile))
+                }
+                withSetting("gwen.behavior.rules", "lenient") {
+                    checkScenarioRules(scenario, Some(specFile))
+                    checkBackgroundRules(background, Some(specFile))
+                }
+            }
+        }
+    }
+
+    "scenarios or backgrounds with G-W-B-T sequence" should "pass imperative and fail declartive rules checks" in {
+        
+        val steps = """
+        |     Given I set some context
+        |      When I perform an action
+        |       But this should not happen
+        |      Then this should happen
+        | """.stripMargin
+        val scenario = createScenario(steps)
+        val background = createBackground(steps)
+
+        withSpecFile(SpecType.feature) { specFile =>
+            withSetting("gwen.behavior.rules", "strict") {
+                intercept[ImproperBehaviorException] {
+                    checkScenarioRules(scenario, Some(specFile))
+                }
+                intercept[ImproperBehaviorException] {
+                    checkBackgroundRules(background, Some(specFile))
+                }
+            }
+            withSetting("gwen.behavior.rules", "lenient") {
+                checkScenarioRules(scenario, Some(specFile))
+                checkBackgroundRules(background, Some(specFile))
+            }
+        }
+
+        withSpecFile(SpecType.meta) { specFile =>
+            withSetting("gwen.behavior.rules", "strict") {
+                checkScenarioRules(scenario, Some(specFile))
+                checkBackgroundRules(background, Some(specFile))
+            }
+            withSetting("gwen.behavior.rules", "lenient") {
+                checkScenarioRules(scenario, Some(specFile))
+                checkBackgroundRules(background, Some(specFile))
+            }
+        }
+    }
+
+    "scenarios or backgrounds with G-W-T-B-B sequence" should "pass imperative and fail declartive rules checks" in {
+        
+        val steps = """
+        |     Given I set some context
+        |      When I perform an action
+        |      Then this should happen
+        |       But this should not happen
+        |       But this should not happen too
+        | """.stripMargin
+        val scenario = createScenario(steps)
+        val background = createBackground(steps)
+
+        withSpecFile(SpecType.feature) { specFile =>
+            withSetting("gwen.behavior.rules", "strict") {
+                intercept[ImproperBehaviorException] {
+                    checkScenarioRules(scenario, Some(specFile))
+                }
+                intercept[ImproperBehaviorException] {
+                    checkBackgroundRules(background, Some(specFile))
+                }
+            }
+            withSetting("gwen.behavior.rules", "lenient") {
+                checkScenarioRules(scenario, Some(specFile))
+                checkBackgroundRules(background, Some(specFile))
+            }
+        }
+
+        withSpecFile(SpecType.meta) { specFile =>
+            withSetting("gwen.behavior.rules", "strict") {
+                checkScenarioRules(scenario, Some(specFile))
+                checkBackgroundRules(background, Some(specFile))
+            }
+            withSetting("gwen.behavior.rules", "lenient") {
+                checkScenarioRules(scenario, Some(specFile))
+                checkBackgroundRules(background, Some(specFile))
+            }
+        }
+    }
+
+    "scenarios or backgrounds with G-W sequence" should "pass imperative and fail declartive rules checks" in {
+        
+        val steps = """
+        |     Given I set some context
+        |      When I perform an action
+        | """.stripMargin
+        val scenario = createScenario(steps)
+        val background = createBackground(steps)
+
+        withSpecFile(SpecType.feature) { specFile =>
+            withSetting("gwen.behavior.rules", "strict") {
+                intercept[ImproperBehaviorException] {
+                    checkScenarioRules(scenario, Some(specFile))
+                }
+                intercept[ImproperBehaviorException] {
+                    checkBackgroundRules(background, Some(specFile))
+                }
+            }
+            withSetting("gwen.behavior.rules", "lenient") {
+                checkScenarioRules(scenario, Some(specFile))
+                checkBackgroundRules(background, Some(specFile))
+            }
+        }
+
+        withSpecFile(SpecType.meta) { specFile =>
+            withSetting("gwen.behavior.rules", "strict") {
+                checkScenarioRules(scenario, Some(specFile))
+                checkBackgroundRules(background, Some(specFile))
+            }
+            withSetting("gwen.behavior.rules", "lenient") {
+                checkScenarioRules(scenario, Some(specFile))
+                checkBackgroundRules(background, Some(specFile))
+            }
+        }
+    }
+
+    "scenarios or backgrounds with G-W-T-G sequence" should "pass imperative and fail declartive rules checks" in {
+        
+        val steps = """
+        |     Given I set some context
+        |      When I perform an action
+        |      Then this should happen
+        |     Given I set another context 
+        | """.stripMargin
+        val scenario = createScenario(steps)
+        val background = createBackground(steps)
+
+        withSpecFile(SpecType.feature) { specFile =>
+            withSetting("gwen.behavior.rules", "strict") {
+                intercept[ImproperBehaviorException] {
+                    checkScenarioRules(scenario, Some(specFile))
+                }
+                intercept[ImproperBehaviorException] {
+                    checkBackgroundRules(background, Some(specFile))
+                }
+            }
+            withSetting("gwen.behavior.rules", "lenient") {
+                checkScenarioRules(scenario, Some(specFile))
+                checkBackgroundRules(background, Some(specFile))
+            }
+        }
+
+        withSpecFile(SpecType.meta) { specFile =>
+            withSetting("gwen.behavior.rules", "strict") {
+                checkScenarioRules(scenario, Some(specFile))
+                checkBackgroundRules(background, Some(specFile))
+            }
+            withSetting("gwen.behavior.rules", "lenient") {
+                checkScenarioRules(scenario, Some(specFile))
+                checkBackgroundRules(background, Some(specFile))
+            }
+        }
+    }
+
+    "scenarios or backgrounds with G-W-T-W-T sequence" should "pass imperative and fail declartive rules checks" in {
+        
+        val steps = """
+        |     Given I set some context
+        |      When I perform an action
+        |      Then this should happen
+        |      When I perform another action
+        |      Then that should happen
+        | """.stripMargin
+        val scenario = createScenario(steps)
+        val background = createBackground(steps)
+
+        withSpecFile(SpecType.feature) { specFile =>
+            withSetting("gwen.behavior.rules", "strict") {
+                intercept[ImproperBehaviorException] {
+                    checkScenarioRules(scenario, Some(specFile))
+                }
+                intercept[ImproperBehaviorException] {
+                    checkBackgroundRules(background, Some(specFile))
+                }
+            }
+            withSetting("gwen.behavior.rules", "lenient") {
+                checkScenarioRules(scenario, Some(specFile))
+                checkBackgroundRules(background, Some(specFile))
+            }
+        }
+
+        withSpecFile(SpecType.meta) { specFile =>
+            withSetting("gwen.behavior.rules", "strict") {
+                checkScenarioRules(scenario, Some(specFile))
+                checkBackgroundRules(background, Some(specFile))
+            }
+            withSetting("gwen.behavior.rules", "lenient") {
+                checkScenarioRules(scenario, Some(specFile))
+                checkBackgroundRules(background, Some(specFile))
+            }
+        }
+    }
+
+    "scenarios or backgrounds with G-W-B sequence" should "pass imperative and fail declartive rules checks" in {
+        
+        val steps = """
+        |     Given I set some context
+        |      When I perform an action
+        |       But this should not happen
+        | """.stripMargin
+        val scenario = createScenario(steps)
+        val background = createBackground(steps)
+
+        withSpecFile(SpecType.feature) { specFile =>
+            withSetting("gwen.behavior.rules", "strict") {
+                intercept[ImproperBehaviorException] {
+                    checkScenarioRules(scenario, Some(specFile))
+                }
+                intercept[ImproperBehaviorException] {
+                    checkBackgroundRules(background, Some(specFile))
+                }
+            }
+            withSetting("gwen.behavior.rules", "lenient") {
+                checkScenarioRules(scenario, Some(specFile))
+                checkBackgroundRules(background, Some(specFile))
+            }
+        }
+
+        withSpecFile(SpecType.meta) { specFile =>
+            withSetting("gwen.behavior.rules", "strict") {
+                checkScenarioRules(scenario, Some(specFile))
+                checkBackgroundRules(background, Some(specFile))
+            }
+            withSetting("gwen.behavior.rules", "lenient") {
+                checkScenarioRules(scenario, Some(specFile))
+                checkBackgroundRules(background, Some(specFile))
+            }
+        }
+    }
+
+    "scenarios or backgrounds with W-T sequence" should "pass imperative and fail declartive rules checks" in {
+        
+        val steps = """
+        |      When I perform an action
+        |      Then this should happen
+        | """.stripMargin
+        val scenario = createScenario(steps)
+        val background = createBackground(steps)
+
+        withSpecFile(SpecType.feature) { specFile =>
+            withSetting("gwen.behavior.rules", "strict") {
+                intercept[ImproperBehaviorException] {
+                    checkScenarioRules(scenario, Some(specFile))
+                }
+                intercept[ImproperBehaviorException] {
+                    checkBackgroundRules(background, Some(specFile))
+                }
+            }
+            withSetting("gwen.behavior.rules", "lenient") {
+                checkScenarioRules(scenario, Some(specFile))
+                checkBackgroundRules(background, Some(specFile))
+            }
+        }
+
+        withSpecFile(SpecType.meta) { specFile =>
+            withSetting("gwen.behavior.rules", "strict") {
+                checkScenarioRules(scenario, Some(specFile))
+                checkBackgroundRules(background, Some(specFile))
+            }
+            withSetting("gwen.behavior.rules", "lenient") {
+                checkScenarioRules(scenario, Some(specFile))
+                checkBackgroundRules(background, Some(specFile))
+            }
+        }
+    }
+
+    "scenarios or backgrounds with G sequence" should "pass imperative and fail declartive rules checks" in {
+        
+        val steps = """
+        |     Given I set some context
+        | """.stripMargin
+        val scenario = createScenario(steps)
+        val background = createBackground(steps)
+
+        withSpecFile(SpecType.feature) { specFile =>
+            withSetting("gwen.behavior.rules", "strict") {
+                intercept[ImproperBehaviorException] {
+                    checkScenarioRules(scenario, Some(specFile))
+                }
+                intercept[ImproperBehaviorException] {
+                    checkBackgroundRules(background, Some(specFile))
+                }
+            }
+            withSetting("gwen.behavior.rules", "lenient") {
+                checkScenarioRules(scenario, Some(specFile))
+                checkBackgroundRules(background, Some(specFile))
+            }
+        }
+
+        withSpecFile(SpecType.meta) { specFile =>
+            withSetting("gwen.behavior.rules", "strict") {
+                checkScenarioRules(scenario, Some(specFile))
+                checkBackgroundRules(background, Some(specFile))
+            }
+            withSetting("gwen.behavior.rules", "lenient") {
+                checkScenarioRules(scenario, Some(specFile))
+                checkBackgroundRules(background, Some(specFile))
+            }
+        }
+    }
+
+    "Cntext steps" should "pass strict Context rules checks" in {
+        val behavior = BehaviorType.Context
+        env.addBehavior(behavior)
+        withSpecFile(SpecType.feature) { _ =>
+            withSetting("gwen.behavior.rules", "strict") {
+                checkStepRules(givenStep, behavior, env)
+                checkStepRules(andStep, behavior, env)
+                intercept[UnexpectedBehaviorException] {
+                    checkStepRules(whenStep, behavior, env)
+                }
+                intercept[UnexpectedBehaviorException] {
+                    checkStepRules(thenStep, behavior, env)
+                }
+                intercept[UnexpectedBehaviorException] {
+                    checkStepRules(butStep, behavior, env)
+                }
+                intercept[UnexpectedBehaviorException] {
+                    checkStepRules(givenStep, BehaviorType.Action, env)
+                }
+                intercept[UnexpectedBehaviorException] {
+                    checkStepRules(andStep, BehaviorType.Action, env)
+                }
+                intercept[UnexpectedBehaviorException] {
+                    checkStepRules(givenStep, BehaviorType.Assertion, env)
+                }
+                intercept[UnexpectedBehaviorException] {
+                    checkStepRules(andStep, BehaviorType.Assertion, env)
+                }
+            }
+        }
+
+        withSpecFile(SpecType.meta) { _ =>
+            withSetting("gwen.behavior.rules", "strict") {
+                checkStepRules(givenStep, behavior, env)
+                checkStepRules(andStep, behavior, env)
+                checkStepRules(whenStep, behavior, env)
+                checkStepRules(thenStep, behavior, env)
+                checkStepRules(butStep, behavior, env)
+                checkStepRules(givenStep, BehaviorType.Action, env)
+                checkStepRules(andStep, BehaviorType.Action, env)
+                checkStepRules(givenStep, BehaviorType.Assertion, env)
+                checkStepRules(andStep, BehaviorType.Assertion, env)
+            }
+        }
+    }
+
+    "Action steps" should "pass strict Action rules checks" in {
+        val behavior = BehaviorType.Action
+        env.addBehavior(behavior)
+        withSpecFile(SpecType.feature) { _ =>
+            withSetting("gwen.behavior.rules", "strict") {
+                checkStepRules(whenStep, behavior, env)
+                checkStepRules(andStep, behavior, env)
+                intercept[UnexpectedBehaviorException] {
+                    checkStepRules(givenStep, behavior, env)
+                }
+                intercept[UnexpectedBehaviorException] {
+                    checkStepRules(thenStep, behavior, env)
+                }
+                intercept[UnexpectedBehaviorException] {
+                    checkStepRules(butStep, behavior, env)
+                }
+                intercept[UnexpectedBehaviorException] {
+                    checkStepRules(whenStep, BehaviorType.Context, env)
+                }
+                intercept[UnexpectedBehaviorException] {
+                    checkStepRules(andStep, BehaviorType.Context, env)
+                }
+                intercept[UnexpectedBehaviorException] {
+                    checkStepRules(whenStep, BehaviorType.Assertion, env)
+                }
+                intercept[UnexpectedBehaviorException] {
+                    checkStepRules(andStep, BehaviorType.Assertion, env)
+                }
+            }
+        }
+
+        withSpecFile(SpecType.meta) { _ =>
+            withSetting("gwen.behavior.rules", "strict") {
+                checkStepRules(whenStep, behavior, env)
+                checkStepRules(andStep, behavior, env)
+                checkStepRules(givenStep, behavior, env)
+                checkStepRules(thenStep, behavior, env)
+                checkStepRules(butStep, behavior, env)
+                checkStepRules(whenStep, BehaviorType.Context, env)
+                checkStepRules(andStep, BehaviorType.Context, env)
+                checkStepRules(whenStep, BehaviorType.Assertion, env)
+                checkStepRules(andStep, BehaviorType.Assertion, env)
+            }
+        }
+    }
+
+    "Assertion steps" should "pass strict Assertion rules checks" in {
+        val behavior = BehaviorType.Assertion
+        env.addBehavior(behavior)
+        withSpecFile(SpecType.feature) { _ =>
+            withSetting("gwen.behavior.rules", "strict") {
+                checkStepRules(thenStep, behavior, env)
+                checkStepRules(andStep, behavior, env)
+                checkStepRules(butStep, behavior, env)
+                intercept[UnexpectedBehaviorException] {
+                    checkStepRules(givenStep, behavior, env)
+                }
+                intercept[UnexpectedBehaviorException] {
+                    checkStepRules(whenStep, behavior, env)
+                }
+                intercept[UnexpectedBehaviorException] {
+                    checkStepRules(thenStep, BehaviorType.Context, env)
+                }
+                intercept[UnexpectedBehaviorException] {
+                    checkStepRules(andStep, BehaviorType.Context, env)
+                }
+                intercept[UnexpectedBehaviorException] {
+                    checkStepRules(butStep, BehaviorType.Context, env)
+                }
+                intercept[UnexpectedBehaviorException] {
+                    checkStepRules(thenStep, BehaviorType.Action, env)
+                }
+                intercept[UnexpectedBehaviorException] {
+                    checkStepRules(andStep, BehaviorType.Action, env)
+                }
+                intercept[UnexpectedBehaviorException] {
+                    checkStepRules(butStep, BehaviorType.Action, env)
+                }
+            }
+        }
+
+        withSpecFile(SpecType.meta) { _ =>
+            withSetting("gwen.behavior.rules", "strict") {
+                checkStepRules(thenStep, behavior, env)
+                checkStepRules(andStep, behavior, env)
+                checkStepRules(butStep, behavior, env)
+                checkStepRules(givenStep, behavior, env)
+                checkStepRules(whenStep, behavior, env)
+                checkStepRules(thenStep, BehaviorType.Context, env)
+                checkStepRules(andStep, BehaviorType.Context, env)
+                checkStepRules(butStep, BehaviorType.Context, env)
+                checkStepRules(thenStep, BehaviorType.Action, env)
+                checkStepRules(andStep, BehaviorType.Action, env)
+                checkStepRules(butStep, BehaviorType.Action, env)
+            }
+        }
+    }
+
+    "Steps of any behavior" should "pass lenient behavior rules checks" in {
+        SpecType.values.foreach { specType =>
+            withSpecFile(specType) { _ =>
+                withSetting("gwen.behavior.rules", "lenient") {
+                    BehaviorType.values foreach { behavior =>
+                        env.addBehavior(behavior)
+                        checkStepRules(givenStep, behavior, env)
+                        checkStepRules(whenStep, behavior, env)
+                        checkStepRules(thenStep, behavior, env)
+                        checkStepRules(andStep, behavior, env)
+                        checkStepRules(butStep, behavior, env)
+                    }
+                }
+            }
+        }
+    }
+
+    private def withSpecFile[T](specType: SpecType.Value)(body: File => T) {
+        val specFile = if (SpecType.isFeature(specType)) {
+            new File("spec.feature")
+        } else {
+            new File("spec.meta")
+        }
+        env.topScope.pushObject("spec.file", specFile)
+        try {
+            body(specFile)
+        } finally {
+            env.topScope.popObject("spec.file")
+        }
+    }
+    
+}

--- a/src/test/scala/gwen/eval/FeatureSetTest.scala
+++ b/src/test/scala/gwen/eval/FeatureSetTest.scala
@@ -21,7 +21,6 @@ import org.scalatest.Matchers
 import java.io.File
 import gwen.dsl.Tag
 import scala.io.Source
-import gwen.dsl.SpecNormaliser
 import gwen.dsl.GherkinParser
 import scala.util.Success
 import scala.util.Failure

--- a/src/test/scala/gwen/eval/SpecNormaliserRulesTest.scala
+++ b/src/test/scala/gwen/eval/SpecNormaliserRulesTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 Branko Juric, Brady Wood
+ * Copyright 2019 Branko Juric, Brady Wood
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-package gwen.dsl
+package gwen.eval
 
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
+import gwen.dsl._
 import gwen.errors.AmbiguousCaseException
-import gwen.eval.DataRecord
 
-class SpecNormaliserTest extends FlatSpec with Matchers with SpecNormaliser with GherkinParser {
+class SpecNormaliserRulesTest extends FlatSpec with Matchers with SpecNormaliser with GherkinParser {
 
   object Feature {
    def apply(name: String, description: List[String]): Feature = new Feature("en", Nil, name, description)
@@ -36,7 +36,7 @@ class SpecNormaliserTest extends FlatSpec with Matchers with SpecNormaliser with
 
   val background = Background(
     "background",
-    List("Initialise"),
+    Nil,
     List(Step(StepKeyword.Given, "background step 1", Passed(2)))
   )
 
@@ -188,7 +188,7 @@ class SpecNormaliserTest extends FlatSpec with Matchers with SpecNormaliser with
     }
   }
   
-  "Data driven feature with csv file and background" should "normalise without error" in {
+  "Data driven feature with csv file" should "normalise without error" in {
     val feature = FeatureSpec(
     Feature("About me", Nil), Some(background), List(
       Scenario(List[Tag](), "What am I?", Nil, None, List(
@@ -203,39 +203,12 @@ class SpecNormaliserTest extends FlatSpec with Matchers with SpecNormaliser with
     result.feature.name should be ("About me, [1] my age=18..")
     result.scenarios.length should be (1)
     result.scenarios(0).background.get.name should be (s"${background.name} (plus input data)")
-    result.scenarios(0).background.get.description should be (List("Initialise", """@Data(file="AboutMe.csv", record=1)"""))
+    result.scenarios(0).background.get.description should be (List("""@Data(file="AboutMe.csv", record=1)"""))
     result.scenarios(0).background.get.steps.size should be (4)
     result.scenarios(0).background.get.steps(0).toString should be ("""Given my age is "18"""")
     result.scenarios(0).background.get.steps(1).toString should be ("""And my gender is "male"""")
     result.scenarios(0).background.get.steps(2).toString should be ("""And my title is "Mr"""")
-    result.scenarios(0).background.get.steps(3).toString should be ("""Given background step 1""")
-    result.scenarios(0).name should be ("What am I?")
-    result.scenarios(0).description should be (Nil)
-    result.scenarios(0).steps(0).toString should be ("""Given I am ${my age} year(s) old""")
-    result.scenarios(0).steps(1).toString should be ("""When I am a ${my gender}""")
-    result.scenarios(0).steps(2).toString should be ("""Then I am a ${my age} year old ${my title}""")
-  }
-
-  "Data driven feature with csv file and no background" should "normalise without error" in {
-    val feature = FeatureSpec(
-    Feature("About me", Nil), None, List(
-      Scenario(List[Tag](), "What am I?", Nil, None, List(
-        Step(StepKeyword.Given, "I am ${my age} year(s) old"),
-        Step(StepKeyword.When, "I am a ${my gender}"),
-        Step(StepKeyword.Then, "I am a ${my age} year old ${my title}"))
-      )), Nil)
-    val data = List(("my age", "18"), ("my gender", "male"), ("my title", "Mr"))
-    val dataRecord = new DataRecord("AboutMe.csv", 1, data)
-    val result = normalise(feature, None, Some(dataRecord))
-    result.background should be (None)
-    result.feature.name should be ("About me, [1] my age=18..")
-    result.scenarios.length should be (1)
-    result.scenarios(0).background.get.name should be ("Input data")
-    result.scenarios(0).background.get.description should be (List("""@Data(file="AboutMe.csv", record=1)"""))
-    result.scenarios(0).background.get.steps.size should be (3)
-    result.scenarios(0).background.get.steps(0).toString should be ("""Given my age is "18"""")
-    result.scenarios(0).background.get.steps(1).toString should be ("""And my gender is "male"""")
-    result.scenarios(0).background.get.steps(2).toString should be ("""And my title is "Mr"""")
+    result.scenarios(0).background.get.steps(3).toString should be ("""And background step 1""")
     result.scenarios(0).name should be ("What am I?")
     result.scenarios(0).description should be (Nil)
     result.scenarios(0).steps(0).toString should be ("""Given I am ${my age} year(s) old""")

--- a/src/test/scala/gwen/eval/SpecNormaliserTest.scala
+++ b/src/test/scala/gwen/eval/SpecNormaliserTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Branko Juric, Brady Wood
+ * Copyright 2015-2017 Branko Juric, Brady Wood
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-package gwen.dsl
+package gwen.eval
 
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers
+import gwen.dsl._
 import gwen.errors.AmbiguousCaseException
-import gwen.eval.DataRecord
 
-class SpecNormaliserRulesTest extends FlatSpec with Matchers with SpecNormaliser with GherkinParser {
+class SpecNormaliserTest extends FlatSpec with Matchers with SpecNormaliser with GherkinParser {
 
   object Feature {
    def apply(name: String, description: List[String]): Feature = new Feature("en", Nil, name, description)
@@ -36,7 +36,7 @@ class SpecNormaliserRulesTest extends FlatSpec with Matchers with SpecNormaliser
 
   val background = Background(
     "background",
-    Nil,
+    List("Initialise"),
     List(Step(StepKeyword.Given, "background step 1", Passed(2)))
   )
 
@@ -188,7 +188,7 @@ class SpecNormaliserRulesTest extends FlatSpec with Matchers with SpecNormaliser
     }
   }
   
-  "Data driven feature with csv file" should "normalise without error" in {
+  "Data driven feature with csv file and background" should "normalise without error" in {
     val feature = FeatureSpec(
     Feature("About me", Nil), Some(background), List(
       Scenario(List[Tag](), "What am I?", Nil, None, List(
@@ -203,12 +203,39 @@ class SpecNormaliserRulesTest extends FlatSpec with Matchers with SpecNormaliser
     result.feature.name should be ("About me, [1] my age=18..")
     result.scenarios.length should be (1)
     result.scenarios(0).background.get.name should be (s"${background.name} (plus input data)")
-    result.scenarios(0).background.get.description should be (List("""@Data(file="AboutMe.csv", record=1)"""))
+    result.scenarios(0).background.get.description should be (List("Initialise", """@Data(file="AboutMe.csv", record=1)"""))
     result.scenarios(0).background.get.steps.size should be (4)
     result.scenarios(0).background.get.steps(0).toString should be ("""Given my age is "18"""")
     result.scenarios(0).background.get.steps(1).toString should be ("""And my gender is "male"""")
     result.scenarios(0).background.get.steps(2).toString should be ("""And my title is "Mr"""")
-    result.scenarios(0).background.get.steps(3).toString should be ("""Given background step 1""")
+    result.scenarios(0).background.get.steps(3).toString should be ("""And background step 1""")
+    result.scenarios(0).name should be ("What am I?")
+    result.scenarios(0).description should be (Nil)
+    result.scenarios(0).steps(0).toString should be ("""Given I am ${my age} year(s) old""")
+    result.scenarios(0).steps(1).toString should be ("""When I am a ${my gender}""")
+    result.scenarios(0).steps(2).toString should be ("""Then I am a ${my age} year old ${my title}""")
+  }
+
+  "Data driven feature with csv file and no background" should "normalise without error" in {
+    val feature = FeatureSpec(
+    Feature("About me", Nil), None, List(
+      Scenario(List[Tag](), "What am I?", Nil, None, List(
+        Step(StepKeyword.Given, "I am ${my age} year(s) old"),
+        Step(StepKeyword.When, "I am a ${my gender}"),
+        Step(StepKeyword.Then, "I am a ${my age} year old ${my title}"))
+      )), Nil)
+    val data = List(("my age", "18"), ("my gender", "male"), ("my title", "Mr"))
+    val dataRecord = new DataRecord("AboutMe.csv", 1, data)
+    val result = normalise(feature, None, Some(dataRecord))
+    result.background should be (None)
+    result.feature.name should be ("About me, [1] my age=18..")
+    result.scenarios.length should be (1)
+    result.scenarios(0).background.get.name should be ("Input data")
+    result.scenarios(0).background.get.description should be (List("""@Data(file="AboutMe.csv", record=1)"""))
+    result.scenarios(0).background.get.steps.size should be (3)
+    result.scenarios(0).background.get.steps(0).toString should be ("""Given my age is "18"""")
+    result.scenarios(0).background.get.steps(1).toString should be ("""And my gender is "male"""")
+    result.scenarios(0).background.get.steps(2).toString should be ("""And my title is "Mr"""")
     result.scenarios(0).name should be ("What am I?")
     result.scenarios(0).description should be (Nil)
     result.scenarios(0).steps(0).toString should be ("""Given I am ${my age} year(s) old""")

--- a/src/test/scala/gwen/sample/outlines/OutlinesInterpreterTest.scala
+++ b/src/test/scala/gwen/sample/outlines/OutlinesInterpreterTest.scala
@@ -28,25 +28,15 @@ import gwen.eval.EvalEngine
 import gwen.dsl.Step
 import gwen.Predefs.RegexContext
 import gwen.eval.GwenInterpreter
+import gwen.eval.support.DefaultEngineSupport
 
 class OutlinesEnvContext(val options: GwenOptions)
   extends EnvContext(options) {
   override def dsl: List[String] = Nil
 }
 
-trait OutlinesEvalEngine extends EvalEngine[OutlinesEnvContext] {
+trait OutlinesEvalEngine extends DefaultEngineSupport[OutlinesEnvContext] {
   override def init(options: GwenOptions): OutlinesEnvContext = new OutlinesEnvContext(options)
-  override def evaluate(step: Step, env: OutlinesEnvContext) {
-    step.expression match {
-      case r"""(.+?)$name is "(.+?)"$$$value""" =>
-        env.scopes.set(name, value)
-      case r"""(.+?)$name should be "(.+?)"$$$value""" =>
-        val actual = env.scopes.get(name)
-        env.perform(assert(actual == value, s"Expected '$value' but got '$actual'"))
-      case _ =>
-        super.evaluate(step, env)
-    }
-  }
 }
 
 class OutlinesInterpreter

--- a/version.sbt
+++ b/version.sbt
@@ -1,6 +1,6 @@
 enablePlugins(GitVersioning)
 
-git.baseVersion := "2.24.0"
+git.baseVersion := "2.25.0"
 
 git.useGitDescribe := true
 


### PR DESCRIPTION
Introduce behavior rules setting to enforce good Gherkin style
  - `gwen.behavior.rules=strict|lenient`
    - `strict`: The following rules are enforced in feature files:
      - Steps in scenarios and backgrounds must satisfy *Given-When-Then* order
      - *Given* steps must set context
      - *When* steps must perform actions
      - *Then* steps must perform assertions
      - *But* steps must perform assertions (and are permitted after *Then* steps)
      - `StepDefs` tagged with:
        - `@Context` : can only be called by *Givens*
        - `@Action` : can only be called by *Whens*
        - `@Assertion` : can only be called by *Thens* or *Buts*
    - `lenient`: no rules are enforced
    - Default is `lenient` for backwards compatibility but plan is to change it 
      to `strict` in v3.0.0 release
