### PR TITLE
Escape new line characters from data table cells

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+3.28.8
+Sep 30, 2022
+- Fix issue gwen-interpreter/gwen-web#96:
+  - Escape new line characters from data table cells
+
 3.28.7
 ======
 Sep 29, 2022

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 enablePlugins(GitVersioning)
 
 // gwen core version
-val gwenVersion = "3.28.7"
+val gwenVersion = "3.28.8"
 
 git.baseVersion := gwenVersion
 git.useGitDescribe := true

--- a/src/main/scala/gwen/core/Predefs.scala
+++ b/src/main/scala/gwen/core/Predefs.scala
@@ -321,6 +321,7 @@ object Formatting {
   def padTailLines(str: String, padding: String) = str.replaceAll("""\r?\n""", s"""\n$padding""")
   def sha256Hash(source: String): String = DigestUtils.sha256Hex(source)
   def upTo2DecimalPlaces(number: Double): String = new DecimalFormat("#.##").format(number)
+  def escapeNewLineChars(source: String): String = source.replaceAll(System.lineSeparator, s"\\\\n")
 
   def formatTable(table: List[(Long, List[String])]): String = {
     (table.indices.toList map { rowIndex => formatTableRow(table, rowIndex) }).mkString("\r\n")

--- a/src/main/scala/gwen/core/node/gherkin/Examples.scala
+++ b/src/main/scala/gwen/core/node/gherkin/Examples.scala
@@ -17,6 +17,7 @@
 package gwen.core.node.gherkin
 
 import gwen.core.Errors
+import gwen.core.Formatting
 import gwen.core.node.GwenNode
 import gwen.core.node.NodeType
 import gwen.core.node.SourceRef
@@ -115,9 +116,9 @@ object Examples {
       examples.getKeyword,
       examples.getName,
       Option(examples.getDescription).filter(_.length > 0).map(_.split("\n").toList.map(_.trim)).getOrElse(Nil),
-      (header.getLocation.getLine, header.getCells.asScala.toList.map(_.getValue)) ::
+      (header.getLocation.getLine, header.getCells.asScala.toList.map(c => Formatting.escapeNewLineChars(c.getValue))) ::
         body.iterator.asScala.toList.map { row =>
-          (Long2long(row.getLocation.getLine), row.getCells.asScala.toList.map(_.getValue))
+          (Long2long(row.getLocation.getLine), row.getCells.asScala.toList.map(c => Formatting.escapeNewLineChars(c.getValue)))
         },
       None,
       Nil

--- a/src/main/scala/gwen/core/node/gherkin/Step.scala
+++ b/src/main/scala/gwen/core/node/gherkin/Step.scala
@@ -235,7 +235,7 @@ object Step {
   def apply(file: Option[File], step: cucumber.Step): Step = {
     val dataTable = step.getDataTable.toScala map { dt =>
       dt.getRows.asScala.toList map { row =>
-        (Long2long(row.getLocation.getLine), row.getCells.asScala.toList.map(_.getValue))
+        (Long2long(row.getLocation.getLine), row.getCells.asScala.toList.map(c => Formatting.escapeNewLineChars(c.getValue)))
       }
     } getOrElse Nil
     val docString = step.getDocString.toScala.filter(_.getContent().trim.length > 0) map { ds =>

--- a/src/test/features/tables/NewLineCharTable.feature
+++ b/src/test/features/tables/NewLineCharTable.feature
@@ -1,0 +1,18 @@
+Feature: New line character in tables
+
+  @DataTable(header="top")
+  @StepDef
+  @ForEach
+  Scenario: Data table test
+    Given value is defined by javascript "'${data[value]}'"
+
+  @StepDef
+  Scenario: I run normal scenario test with "<value>" value
+    Given value is defined by javascript "'$<value>'"
+
+  Scenario: Test
+   When I run normal scenario test with "value with \n character" value
+   Then Data table test
+        | value                            |
+        | value with \n character          |
+        | value with escaped \\n character |

--- a/src/test/scala/gwen/core/features/TablesNewLineCharTest.scala
+++ b/src/test/scala/gwen/core/features/TablesNewLineCharTest.scala
@@ -24,7 +24,7 @@ import gwen.core.status._
 
 import java.io.File
 
-class AdhocFeatureTest extends BaseTest {
+class TablesNewLineCharTest extends BaseTest {
 
   val feature = "src/test/features/tables/NewLineCharTable.feature"
 


### PR DESCRIPTION
Fixes issue gwen-interprter/gwen-web#96.

The problem was that the latest Gherkin parser no longer escapes new line characters from table cells. It expects `\\n` instead of `\n`.

 Solution was to escape any new line characters after parsing.